### PR TITLE
⬆️ bump `basedpyright` to `1.26.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,11 @@ dependencies = []
 numpy = ["numtype[numpy]"]
 dev = [
     {include-group = "numpy"},
-    "ruff>=0.9.4",
-    "basedmypy[faster-cache]>=2.9.1",
-    "basedpyright>=1.25.0",
     "libcst>=1.6.0",
+    "ruff>=0.9.4",
+    # keep in sync with test/pyproject.toml
+    "basedmypy[faster-cache]>=2.9.1",
+    "basedpyright>=1.26.0",
 ]
 
 
@@ -91,8 +92,9 @@ include = [
     "test/static/sanity",
     "tool",
 ]
-ignore = [".venv"]
+ignore = [".venv", "test/.venv"]
 stubPath = "src"
+venvPath = "./test"
 pythonPlatform = "All"
 pythonVersion = "3.10"
 typeCheckingMode = "standard" # TODO(jorenham): set to "all"

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     static = "main:static"
 
 [tool.uv.sources]
-numtype = {path = ".." }
+numtype = {path = ".."}
 
 [tool.hatch.build]
 packages = ["."]

--- a/test/uv.lock
+++ b/test/uv.lock
@@ -101,10 +101,10 @@ requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2
 [package.metadata.requires-dev]
 dev = [
     { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.9.1" },
-    { name = "basedpyright", specifier = ">=1.25.0" },
+    { name = "basedpyright", specifier = ">=1.26.0" },
     { name = "libcst", specifier = ">=1.6.0" },
     { name = "numtype", extras = ["numpy"] },
-    { name = "ruff", specifier = ">=0.9.3" },
+    { name = "ruff", specifier = ">=0.9.4" },
 ]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,14 +43,14 @@ faster-cache = [
 
 [[package]]
 name = "basedpyright"
-version = "1.25.0"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/ca/db0d980181a198a92f3e7cf6b8b55a45957019d6ac55c6909591406616d0/basedpyright-1.25.0.tar.gz", hash = "sha256:8d0c25ae285600684fb7a8015be688970259c318904fa1cd2b59ee5a63575e74", size = 21447756 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c2/5685d040d4f2598788d42bfd2db5f808e9aa2eaee77fcae3c2fbe4ea0e7c/basedpyright-1.26.0.tar.gz", hash = "sha256:5e01f6eb9290a09ef39672106cf1a02924fdc8970e521838bc502ccf0676f32f", size = 24932771 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/8d/2dfcf9c8bc5bd552b0ab5ff7e381c4b18f40bee867e05634a44cb23f348a/basedpyright-1.25.0-py3-none-any.whl", hash = "sha256:5c18aebe675a88976b749a2862d1c6188f6a331a050b16536c48481a8c545efc", size = 11443631 },
+    { url = "https://files.pythonhosted.org/packages/8e/72/65308f45bb73efc93075426cac5f37eea937ae364aa675785521cb3512c7/basedpyright-1.26.0-py3-none-any.whl", hash = "sha256:5a6a17f2c389ec313dd2c3644f40e8221bc90252164802e626055341c0a37381", size = 11504579 },
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2
 [package.metadata.requires-dev]
 dev = [
     { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.9.1" },
-    { name = "basedpyright", specifier = ">=1.25.0" },
+    { name = "basedpyright", specifier = ">=1.26.0" },
     { name = "libcst", specifier = ">=1.6.0" },
     { name = "numtype", extras = ["numpy"] },
     { name = "ruff", specifier = ">=0.9.4" },


### PR DESCRIPTION
https://github.com/DetachHead/basedpyright/releases/tag/v1.26.0