### PR TITLE
🔨 use `mypy 1.15.0` (for the time being)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           src/numpy-stubs/matlib.pyi
           src/numpy-stubs/version.pyi
 
-      - name: basedmypy (numpy-stubs)
+      - name: mypy (numpy-stubs)
         run: >
           uv run --no-editable mypy
           src/numpy-stubs/_typing
@@ -86,8 +86,8 @@ jobs:
       - name: basedpyright (test)
         run: uv run basedpyright test
 
-      - name: basedmypy (test)
-        run: uv run test/bmp.py
+      - name: mypy (test)
+        run: uv run test/mypy.py
 
       - name: basedpyright (tool)
         run: uv run basedpyright tool

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,5 @@
   "evenBetterToml.formatter.indentString": "    ",
   "evenBetterToml.formatter.indentTables": true,
   "evenBetterToml.formatter.trailingNewline": true,
-  "mypy-type-checker.path": ["uv", "run", "test/bmp.py", "--ide"]
+  "mypy-type-checker.path": ["uv", "run", "test/mypy.py"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.10"
-packages = [{include = "src/numpy-stubs" }]
+packages = [{include = "src/numpy-stubs"}]
 dependencies = []
 
 
@@ -46,7 +46,8 @@ dev = [
     {include-group = "numpy"},
     "libcst>=1.6.0",
     "ruff>=0.9.4",
-    "basedmypy[faster-cache]>=2.9.1",  # keep in sync with test/my.py
+    "mypy[faster-cache]>=1.15.0",
+    # "basedmypy[faster-cache]>=2.9.1",
     "basedpyright>=1.26.0",
     "pytest>=8.3.4",
 ]
@@ -78,20 +79,22 @@ show_error_code_links = false
 show_traceback = false
 
 strict = true
-disable_bytearray_promotion = true
-disable_memoryview_promotion = true
+strict_bytes = true
+strict_concatenate = true
+local_partial_types = true
+# disable_bytearray_promotion = true
+# disable_memoryview_promotion = true
 enable_error_code = ["ignore-without-code", "truthy-bool"]
+disable_error_code = ["explicit-override"]
+enable_incomplete_feature = ["PreciseTupleTypes"]
 disallow_any_explicit = false
 disallow_any_expr = false
 disallow_any_decorated = false
-warn_unused_ignores = true
-# TODO
-disable_error_code = ["explicit-override"]
-# basedmypy/mypy compat
-bare_literals = false
-default_return = false
-disallow_untyped_calls = false
+warn_incomplete_stub = true
 warn_unreachable = false
+# basedmypy/mypy compat
+# bare_literals = false
+# default_return = false
 
 
 [tool.pyright]

--- a/src/numpy-stubs/_core/multiarray.pyi
+++ b/src/numpy-stubs/_core/multiarray.pyi
@@ -58,7 +58,7 @@ from numpy._typing import (
     _SupportsDType,
     _TD64Like_co,
 )
-from numpy._typing._ufunc import _2PTuple, _PyFunc_Nin1P_Nout2P, _PyFunc_Nin1_Nout1, _PyFunc_Nin2_Nout1, _PyFunc_Nin3P_Nout1
+from numpy._typing._ufunc import _PyFunc_Nin1P_Nout2P, _PyFunc_Nin1_Nout1, _PyFunc_Nin2_Nout1, _PyFunc_Nin3P_Nout1
 from numpy.lib._array_utils_impl import normalize_axis_index
 
 __all__ = [
@@ -154,6 +154,8 @@ __all__ = [
 ]
 
 _ReturnT = TypeVar("_ReturnT")
+_ReturnT1 = TypeVar("_ReturnT1")
+_ReturnT2 = TypeVar("_ReturnT2")
 _IdentityT = TypeVar("_IdentityT")
 
 _SCT = TypeVar("_SCT", bound=np.generic)
@@ -762,6 +764,10 @@ def fromstring(
     like: _SupportsArrayFunc | None = ...,
 ) -> NDArray[Any]: ...
 
+_3P: TypeAlias = L[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+_2P: TypeAlias = L[2] | _3P
+_1P: TypeAlias = L[1, 2] | _3P
+
 #
 @overload
 def frompyfunc(
@@ -770,7 +776,7 @@ def frompyfunc(
     nin: L[1],
     nout: L[1],
     *,
-    identity: None = ...,
+    identity: None = None,
 ) -> _PyFunc_Nin1_Nout1[_ReturnT, None]: ...
 @overload
 def frompyfunc(
@@ -788,7 +794,7 @@ def frompyfunc(
     nin: L[2],
     nout: L[1],
     *,
-    identity: None = ...,
+    identity: None = None,
 ) -> _PyFunc_Nin2_Nout1[_ReturnT, None]: ...
 @overload
 def frompyfunc(
@@ -803,38 +809,56 @@ def frompyfunc(
 def frompyfunc(
     func: Callable[..., _ReturnT],
     /,
-    nin: SupportsIndex,
+    nin: _3P,
     nout: L[1],
     *,
-    identity: None = ...,
+    identity: None = None,
 ) -> _PyFunc_Nin3P_Nout1[_ReturnT, None, int]: ...
 @overload
 def frompyfunc(
     func: Callable[..., _ReturnT],
     /,
-    nin: SupportsIndex,
+    nin: _3P,
     nout: L[1],
     *,
     identity: _IdentityT,
 ) -> _PyFunc_Nin3P_Nout1[_ReturnT, _IdentityT, int]: ...
 @overload
 def frompyfunc(
-    func: Callable[..., _2PTuple[_ReturnT]],
+    func: Callable[..., tuple[_ReturnT1, _ReturnT2]],
     /,
-    nin: SupportsIndex,
-    nout: SupportsIndex,
+    nin: _1P,
+    nout: _2P,
     *,
-    identity: None = ...,
-) -> _PyFunc_Nin1P_Nout2P[_ReturnT, None, int, int]: ...
+    identity: None = None,
+) -> _PyFunc_Nin1P_Nout2P[_ReturnT1 | _ReturnT2, None, int, int]: ...
 @overload
 def frompyfunc(
-    func: Callable[..., _2PTuple[_ReturnT]],
+    func: Callable[..., tuple[_ReturnT1, _ReturnT2]],
     /,
-    nin: SupportsIndex,
-    nout: SupportsIndex,
+    nin: _1P,
+    nout: _2P,
     *,
     identity: _IdentityT,
-) -> _PyFunc_Nin1P_Nout2P[_ReturnT, _IdentityT, int, int]: ...
+) -> _PyFunc_Nin1P_Nout2P[_ReturnT1 | _ReturnT2, _IdentityT, int, int]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., tuple[_ReturnT1, _ReturnT2, Unpack[tuple[_ReturnT, ...]]]],
+    /,
+    nin: _1P,
+    nout: _2P,
+    *,
+    identity: None = None,
+) -> _PyFunc_Nin1P_Nout2P[_ReturnT1 | _ReturnT2 | _ReturnT, None, int, int]: ...
+@overload
+def frompyfunc(
+    func: Callable[..., tuple[_ReturnT1, _ReturnT2, Unpack[tuple[_ReturnT, ...]]]],
+    /,
+    nin: _1P,
+    nout: _2P,
+    *,
+    identity: _IdentityT,
+) -> _PyFunc_Nin1P_Nout2P[_ReturnT1 | _ReturnT2 | _ReturnT, _IdentityT, int, int]: ...
 @overload
 def frompyfunc(
     func: Callable[..., Any],

--- a/test/README.md
+++ b/test/README.md
@@ -5,11 +5,11 @@
 Mypy and basedmypy will only recognize the `src/numpy-stubs` if `numtype` is installed in an
 isolated project, and it cannot be editable.
 
-The `bmp.py` script creates an isolated environment, that doesn't include numpy, and will run
+The `mypy.py` script creates an isolated environment, that doesn't include numpy, and will run
 basedmypy. If no paths are provided, it will default to `--explicit-package-bases test`.
 
 ```bash
-uv run test/bmp.py [OPTIONS]
+uv run test/mypy.py [OPTIONS]
 ```
 
 ## basedpyright

--- a/test/mypy.py
+++ b/test/mypy.py
@@ -1,8 +1,9 @@
 # /// script
 # dependencies = [
 #     "numtype",
+#     # "basedmypy[faster-cache]",
+#     "mypy[faster-cache]",
 #     "pytest",  # imported in test/runtime
-#     "basedmypy[faster-cache]",
 # ]
 #
 # [tool.uv]
@@ -13,7 +14,7 @@
 # ///
 
 """
-Usage: `uv run test/bmp.py <OPTIONS>`
+Usage: `uv run test/mypy.py <OPTIONS>`
 """
 
 import subprocess

--- a/test/static/accept/ndarray_conversion.pyi
+++ b/test/static/accept/ndarray_conversion.pyi
@@ -56,12 +56,9 @@ assert_type(f8_3d.astype(np.int16), np.ndarray[tuple[int, int, int], np.dtype[np
 assert_type(np.astype(f8_3d, np.int16), np.ndarray[tuple[int, int, int], np.dtype[np.int16]])
 assert_type(
     i4_2d.astype(uncertain_dtype),  # pyright: ignore[reportAssertTypeFailure]  # ndarray[(int, int), np.dtype[Any]]
-    np.ndarray[tuple[int, int], np.dtype[np.int32 | np.float64 | np.str_]],
+    np.ndarray[tuple[int, int], np.dtype[np.generic]],
 )
-assert_type(
-    np.astype(i4_2d, uncertain_dtype),  # pyright: ignore[reportAssertTypeFailure]  # ndarray[(int, int), np.dtype[Any]]
-    np.ndarray[tuple[int, int], np.dtype[np.int32 | np.float64 | np.str_]],
-)
+assert_type(np.astype(i4_2d, uncertain_dtype), np.ndarray[tuple[int, int], np.dtype[Any]])
 
 # byteswap
 assert_type(i0_nd.byteswap(), npt.NDArray[np.int_])

--- a/uv.lock
+++ b/uv.lock
@@ -2,46 +2,6 @@ version = 1
 requires-python = ">=3.10"
 
 [[package]]
-name = "basedmypy"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "basedtyping" },
-    { name = "mypy-extensions" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/79ca3b8247f64a40aee97db4073d3b9aa41eb96dadd76dd71b5601fa07ff/basedmypy-2.9.1.tar.gz", hash = "sha256:9e1d914650987612279a796dfc3768f96788fc636064e8204af896aa3b16d520", size = 5496540 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/0b/a192452406691446e5677de66af07bf310226f03412019f38565e09a4869/basedmypy-2.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c2cbade2d04d2a53c5bc7c7745964f157502e169960076e7dbc9ef6bf4cd5f41", size = 11556322 },
-    { url = "https://files.pythonhosted.org/packages/33/b5/b77fbda7b3a6ec76de9a0eec96af30276e2dcc502af05fa83a09dfb82fc7/basedmypy-2.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86acf505fa67d367c6e5ba737e861863ff1fcf6e1af5345ce0dcc46a7462c33a", size = 10671756 },
-    { url = "https://files.pythonhosted.org/packages/55/68/b217ab503678e8278b0c0f3d507dd2f4821355426ea6f33645a4d1ef1cb5/basedmypy-2.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:464478bd283e5ac121da300c51176a44194bd9099d0fdd04df2639ba336826af", size = 13223124 },
-    { url = "https://files.pythonhosted.org/packages/d6/f8/3c4b482ab82a0d27b82551295dff3d0b06bfc2ff701c01f5e6ef4dd8be7d/basedmypy-2.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4810befb4abb1cb84f88227be8049ebcbffba96198c3f71e682b85b8d95efa1f", size = 13410202 },
-    { url = "https://files.pythonhosted.org/packages/24/e9/8391eb42a9f577c1dbf2a6a4d7b18ea49e25ffa624996a1577b2338cf66a/basedmypy-2.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:379736cbbf30ba0bba7896496c1ae7a67b6766595dd9bdbed3bffc00f6e02526", size = 10081514 },
-    { url = "https://files.pythonhosted.org/packages/fe/8f/07f2e1b024ddf9793bf3155b5f9ce6f192765a8cf940b0b126d05c399309/basedmypy-2.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cf59b8784878b802717cefc151d2b94606878c627ec07f157d287f510bfafea", size = 11476217 },
-    { url = "https://files.pythonhosted.org/packages/d1/97/2566f78513d744496ecfc6ededd906e0e4654a198fc8b9e587fbe6c5447a/basedmypy-2.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:043c516ebfdd9647b973507b0e98bfefca0d366db01af7615f404eba21f8b7bc", size = 10603037 },
-    { url = "https://files.pythonhosted.org/packages/70/8e/78cb609b6a60c4518393aec39eeec3d51605504df425f07650627f44dbbc/basedmypy-2.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbd5e85f7919673018aa92eefe119e2436e7b0ee716b1fc8340286ec5cc856d9", size = 13132523 },
-    { url = "https://files.pythonhosted.org/packages/12/9b/1805bebd9d2a1b9d96f6e61669f96ccb6d86f31945f3687dc9af3adac903/basedmypy-2.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f53f89382de80dfde18744cb1380ab75010c553b9170d91d7fe4074590140c5a", size = 13289475 },
-    { url = "https://files.pythonhosted.org/packages/f8/45/87216b4228a01418d0f0a1fe80b71edb50df7a69ea393e5e891ec1ad4af6/basedmypy-2.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:a32594e4607f1dbe77d2f67e6cce2b6183d70db7f07d0d9643743d9a7e8e47a4", size = 10077706 },
-    { url = "https://files.pythonhosted.org/packages/83/d5/c471c886b36e7fe7d6b4dabbe0fa0e5702bb2dac39d7465e89f8f067dcba/basedmypy-2.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:073a00a4aaea06129ebafa72d573cbf79fd72419f240dadd4254ae919e34c316", size = 11620652 },
-    { url = "https://files.pythonhosted.org/packages/ca/79/b0ad99da0d8c01e2bc5e8ac236ecf6ef38a7840d7ce0455eb08c9a0d7b58/basedmypy-2.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:38bb89c82fa796192534b374e6622879bdbc89b4ccc20cce960fa13b1d16b3df", size = 10562509 },
-    { url = "https://files.pythonhosted.org/packages/2b/a9/2177bbea3fd5196efb33f34f5e3023b332d76de590613b6a15d8f5c15058/basedmypy-2.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6bb6bba1e0b69339fa9740a1c35ed8a1fcf0f39e1879f54c246d34bad727d124", size = 13268020 },
-    { url = "https://files.pythonhosted.org/packages/ae/c4/07435ae3fb8ef087d2044b2795f8ccd8ef8579663bddf612c43d9913e7d3/basedmypy-2.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:338616bef32dfd93ec55bd54147a4e40c3ecc82b97411e26e230375183fabcb3", size = 13379129 },
-    { url = "https://files.pythonhosted.org/packages/08/11/964ed7915db0ced1201a54d475e4d17d979cbe8f1da73ee97b585d03a993/basedmypy-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:b8a7bc4f83a7811d4d8bb26329ea7f2333fcabc6e71752f7feb0a1c1a6916143", size = 10181854 },
-    { url = "https://files.pythonhosted.org/packages/4d/48/a44d41e24ede0b122376fec5eac5dd0b8d673aa00715159d57140f6b154f/basedmypy-2.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a3e42415327c49c5971983fe8b9a600380a99ac32bff5e61400d5127b7be6aa6", size = 11621044 },
-    { url = "https://files.pythonhosted.org/packages/2b/36/d328594a371a1b43ca5fe8f55d1a4c2a8ea63153aa5c0995fbd19658d3c3/basedmypy-2.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2dbdb81e14c76fe2086da9de585c2d4c64a537bf233245b4fecb5cbe214133e", size = 10564883 },
-    { url = "https://files.pythonhosted.org/packages/74/f1/e2cb3956e44a0cef51427ac458fc40c00c1713f9d259ce657a0fcf10850b/basedmypy-2.9.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03ae13c996c22f5a19c8d6742d31c6d6025e9f3d54cc10d91c41dac5f99d436c", size = 13269695 },
-    { url = "https://files.pythonhosted.org/packages/5d/bf/8bb089cde603a5ec3392d8f22e851bc6b1e3b01834081a95b2b9b8c821b3/basedmypy-2.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e80e8ed2566448433d519b4c6d83b27455596cd1e1f9ac301e99ae72888f4850", size = 13366985 },
-    { url = "https://files.pythonhosted.org/packages/5c/df/83ba17a372595f5429860c1fa1e16a073f3a7b9078ced9ad925e5a19c033/basedmypy-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:41e1a5f6c326f27dedf41ed1d747b7e7b4747bb870d165e92b2d5067fad5349c", size = 10193192 },
-    { url = "https://files.pythonhosted.org/packages/9b/74/a316af9e4023afd088b473ffb2f74bff23ee97867c62917b2af693b36149/basedmypy-2.9.1-py3-none-any.whl", hash = "sha256:07b4b567d8871c63b6b896784a607fe375481a4881225d124bec1ef296b2a886", size = 2794586 },
-]
-
-[package.optional-dependencies]
-faster-cache = [
-    { name = "orjson" },
-]
-
-[[package]]
 name = "basedpyright"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -51,18 +11,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/c2/5685d040d4f2598788d42bfd2db5f808e9aa2eaee77fcae3c2fbe4ea0e7c/basedpyright-1.26.0.tar.gz", hash = "sha256:5e01f6eb9290a09ef39672106cf1a02924fdc8970e521838bc502ccf0676f32f", size = 24932771 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/72/65308f45bb73efc93075426cac5f37eea937ae364aa675785521cb3512c7/basedpyright-1.26.0-py3-none-any.whl", hash = "sha256:5a6a17f2c389ec313dd2c3644f40e8221bc90252164802e626055341c0a37381", size = 11504579 },
-]
-
-[[package]]
-name = "basedtyping"
-version = "0.1.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/36/7ba70ab751f08f8619c9c1985899cc75223fef6b9583159414e08a1240f3/basedtyping-0.1.10.tar.gz", hash = "sha256:d7600917ec9f232c9eb4266916c2ea5a4719ffca59fb7902fc96fd59a4678110", size = 14672 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/4a/76fe7ddbb90aadaeb298dbb57e562a365f21a6fa17d3c69e73cb3c0c84e8/basedtyping-0.1.10-py3-none-any.whl", hash = "sha256:8952416f8fd196d25c1f6d6bb556223183e928c944bee4bd0c49af659677dea9", size = 15045 },
 ]
 
 [[package]]
@@ -129,6 +77,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/39/dcfe6c02e087e3241e8e799b2ddb92e32a65076eec846205e96e3a928139/libcst-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3fb953fc0155532f366ff40f6a23f191250134d6928e02074ae4eb3531fa6c30", size = 2248820 },
     { url = "https://files.pythonhosted.org/packages/20/5b/db239fcf1417bdff283ed76b027b4039e1c377d38aa3b979f32bcf34fa94/libcst-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2f3c85602e5a6d3aec0a8fc74230363f943004d7c2b2a6a1c09b320b61692241", size = 2365139 },
     { url = "https://files.pythonhosted.org/packages/38/7f/ed56f5724305c08235d1edc580275aa13c8303e93d374d4fe73162907e88/libcst-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:c4486921bebd33d67bbbd605aff8bfaefd2d13dc73c20c1fde2fb245880b7fd6", size = 2070695 },
+]
+
+[[package]]
+name = "mypy"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/f8/65a7ce8d0e09b6329ad0c8d40330d100ea343bd4dd04c4f8ae26462d0a17/mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13", size = 10738433 },
+    { url = "https://files.pythonhosted.org/packages/b4/95/9c0ecb8eacfe048583706249439ff52105b3f552ea9c4024166c03224270/mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559", size = 9861472 },
+    { url = "https://files.pythonhosted.org/packages/84/09/9ec95e982e282e20c0d5407bc65031dfd0f0f8ecc66b69538296e06fcbee/mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b", size = 11611424 },
+    { url = "https://files.pythonhosted.org/packages/78/13/f7d14e55865036a1e6a0a69580c240f43bc1f37407fe9235c0d4ef25ffb0/mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3", size = 12365450 },
+    { url = "https://files.pythonhosted.org/packages/48/e1/301a73852d40c241e915ac6d7bcd7fedd47d519246db2d7b86b9d7e7a0cb/mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b", size = 12551765 },
+    { url = "https://files.pythonhosted.org/packages/77/ba/c37bc323ae5fe7f3f15a28e06ab012cd0b7552886118943e90b15af31195/mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828", size = 9274701 },
+    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
+    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
+    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
+    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
+    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
+    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
+    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
+    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
+    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
+    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
+    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
+    { url = "https://files.pythonhosted.org/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445", size = 10788592 },
+    { url = "https://files.pythonhosted.org/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d", size = 9753611 },
+    { url = "https://files.pythonhosted.org/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5", size = 11438443 },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541 },
+    { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348 },
+    { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648 },
+    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
+]
+
+[package.optional-dependencies]
+faster-cache = [
+    { name = "orjson" },
 ]
 
 [[package]]
@@ -230,9 +221,9 @@ numpy = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "basedmypy", extra = ["faster-cache"] },
     { name = "basedpyright" },
     { name = "libcst" },
+    { name = "mypy", extra = ["faster-cache"] },
     { name = "numtype", extra = ["numpy"] },
     { name = "pytest" },
     { name = "ruff" },
@@ -246,9 +237,9 @@ requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "basedmypy", extras = ["faster-cache"], specifier = ">=2.9.1" },
     { name = "basedpyright", specifier = ">=1.26.0" },
     { name = "libcst", specifier = ">=1.6.0" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.9.4" },


### PR DESCRIPTION
... until the next basedmypy is released