### PR TITLE
🏷️ stub `lib.introspect`

### DIFF
--- a/src/numpy-stubs/lib/introspect.pyi
+++ b/src/numpy-stubs/lib/introspect.pyi
@@ -1,0 +1,3 @@
+__all__ = ["opt_func_info"]
+
+def opt_func_info(func_name: str | None = None, signature: str | None = None) -> dict[str, dict[str, dict[str, str]]]: ...


### PR DESCRIPTION
closes #34