### PR TITLE
📦 new public `numtype` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,11 @@ classifiers = [
     "Typing :: Stubs Only",
     "Typing :: Typed",
 ]
+packages = [
+    {include = "src/numpy-stubs"},
+    {include = "src/numtype"},
+]
 requires-python = ">=3.10"
-packages = [{include = "src/numpy-stubs"}]
 dependencies = []
 
     [project.optional-dependencies]
@@ -53,7 +56,7 @@ dev = [
 
 
 [tool.hatch.build]
-packages = ["src/numpy-stubs"]
+packages = ["src/numpy-stubs", "src/numtype"]
 
     [tool.hatch.build.targets.sdist]
     exclude = [
@@ -64,6 +67,7 @@ packages = ["src/numpy-stubs"]
         "/test",
         "/tool",
         ".libcst.codemod.yaml",
+        ".pre-commit-config.yaml",
         "CONTRIBUTING.md",
         "uv.lock",
     ]
@@ -98,10 +102,9 @@ warn_unreachable = false
 [tool.pyright]
 include = [
     "src/numpy-stubs",
-    "test/runtime/accept",
-    "test/static/accept",
-    "test/static/reject",
-    "test/static/sanity",
+    "src/numtype",
+    "test/runtime",
+    "test/static",
     "tool",
 ]
 ignore = [".venv", "test/.venv"]
@@ -139,7 +142,7 @@ strictGenericNarrowing = true
 
 
 [tool.ruff]
-src = ["src/numpy-stubs", "test/runtime", "test/static", "tool"]
+src = ["src/numpy-stubs", "src/numtype", "test", "tool"]
 extend-exclude = [".git", ".mypy_cache", ".tox", ".venv"]
 force-exclude = true
 # https://typing.readthedocs.io/en/latest/guides/writing_stubs.html#maximum-line-length
@@ -189,6 +192,7 @@ preview = true
             "datetime" = "dt"
             "numpy" = "np"
             "numpy.typing" = "npt"
+            "numtype" = "nt"
 
         [tool.ruff.lint.isort]
         case-sensitive = true

--- a/src/numpy-stubs/ruff.toml
+++ b/src/numpy-stubs/ruff.toml
@@ -1,4 +1,4 @@
-extend = "../pyproject.toml"
+extend = "../../pyproject.toml"
 line-length = 130
 
 [lint]

--- a/src/numtype/__init__.py
+++ b/src/numtype/__init__.py
@@ -1,0 +1,7 @@
+"""A superset of `numpy.typing`. Will be expanded in the future."""
+
+from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray  # noqa: ICN003
+
+from .version import __version__
+
+__all__ = ["ArrayLike", "DTypeLike", "NBitBase", "NDArray", "__version__"]

--- a/src/numtype/ruff.toml
+++ b/src/numtype/ruff.toml
@@ -1,0 +1,2 @@
+extend = "../../pyproject.toml"
+line-length = 88

--- a/src/numtype/version.py
+++ b/src/numtype/version.py
@@ -1,0 +1,7 @@
+"""Module to expose more detailed version info for the installed `numtype`."""
+
+import importlib.metadata
+from typing import Final
+
+__all__ = ["__version__"]
+__version__: Final = importlib.metadata.version(__package__ or __file__.split("/")[-1])

--- a/test/runtime/test_numtype.py
+++ b/test/runtime/test_numtype.py
@@ -1,0 +1,18 @@
+import numtype as nt
+import pytest
+
+import numpy as np
+import numpy.typing as npt
+
+
+def test_superset() -> None:
+    assert set(nt.__all__) > set(npt.__all__)
+
+
+@pytest.mark.parametrize("name", npt.__all__)
+def test_reexport(name: str) -> None:
+    assert getattr(nt, name) is getattr(npt, name)
+
+
+def test_version() -> None:
+    assert nt.__version__.startswith(np.__version__)


### PR DESCRIPTION
it currently only re-exports the `numpy.typing` type-aliases