### PR TITLE
🐛 fix typing errors in `ndenumerate`

### DIFF
--- a/src/numpy-stubs/__init__.pyi
+++ b/src/numpy-stubs/__init__.pyi
@@ -234,7 +234,6 @@ from numpy._typing import (
     _DTypeLike,
     _DTypeLikeVoid,
     _DoubleCodes,
-    _FiniteNestedSequence,
     _FlexibleCodes,
     _Float16Codes,
     _Float32Codes,
@@ -384,6 +383,8 @@ from numpy.lib._index_tricks_impl import (
     index_exp,
     ix_,
     mgrid,
+    ndenumerate,
+    ndindex,
     ogrid,
     r_,
     ravel_multi_index,
@@ -5174,49 +5175,6 @@ bitwise_invert: Final = invert
 bitwise_right_shift: Final = right_shift
 permute_dims: Final = transpose
 pow: Final = power
-
-class ndenumerate(Generic[_SCT_co]):
-    @property
-    def iter(self) -> flatiter[NDArray[_SCT_co]]: ...
-
-    #
-    @overload
-    def __new__(cls, arr: _FiniteNestedSequence[_SupportsArray[dtype[_SCT_co]]]) -> Self: ...
-    @overload
-    def __new__(cls, arr: str | _NestedSequence[str]) -> ndenumerate[str_]: ...
-    @overload
-    def __new__(cls, arr: bytes | _NestedSequence[bytes]) -> ndenumerate[bytes_]: ...
-    @overload
-    def __new__(cls, arr: builtins.bool | _NestedSequence[builtins.bool]) -> ndenumerate[np.bool]: ...
-    @overload
-    def __new__(cls, arr: int | _NestedSequence[int]) -> ndenumerate[int_]: ...
-    @overload
-    def __new__(cls, arr: float | _NestedSequence[float]) -> ndenumerate[float64]: ...
-    @overload
-    def __new__(cls, arr: complex | _NestedSequence[complex]) -> ndenumerate[complex128]: ...
-    @overload
-    def __new__(cls, arr: object) -> ndenumerate[object_]: ...
-
-    # The first overload is a (semi-)workaround for a mypy bug (tested with v1.10 and v1.11)
-    @overload
-    def __next__(self: ndenumerate[np.bool | datetime64 | timedelta64 | number | flexible], /) -> tuple[_Shape, _SCT_co]: ...
-    @overload
-    def __next__(self: ndenumerate[object_], /) -> tuple[_Shape, Any]: ...
-    @overload
-    def __next__(self, /) -> tuple[_Shape, _SCT_co]: ...
-
-    #
-    def __iter__(self) -> Self: ...
-
-class ndindex:
-    @overload
-    def __init__(self, shape: tuple[SupportsIndex, ...], /) -> None: ...
-    @overload
-    def __init__(self, *shape: SupportsIndex) -> None: ...
-
-    #
-    def __iter__(self) -> Self: ...
-    def __next__(self) -> _Shape: ...
 
 class matrix(ndarray[_2DShapeT_co, _DType_co]):
     __array_priority__: ClassVar[float] = ...

--- a/src/numpy-stubs/lib/_index_tricks_impl.pyi
+++ b/src/numpy-stubs/lib/_index_tricks_impl.pyi
@@ -1,11 +1,23 @@
 from _typeshed import Incomplete
 from collections.abc import Sequence
 from typing import Any, Final, Generic, Literal as L, SupportsIndex, TypeAlias, final, overload
-from typing_extensions import TypeVar
+from typing_extensions import Self, TypeVar
 
 import numpy as np
-from _numtype import Array, Is, Matrix, Sequence_nd, _ToArray1_nd
-from numpy import ndenumerate, ndindex  # noqa: ICN003
+from _numtype import (
+    Array,
+    Is,
+    Matrix,
+    Sequence_nd,
+    ToBool_nd,
+    ToBytes_nd,
+    ToComplex128_nd,
+    ToFloat64_nd,
+    ToIntP_nd,
+    ToObject_nd,
+    ToStr_nd,
+    _ToArray1_nd,
+)
 from numpy._core.multiarray import ravel_multi_index, unravel_index
 from numpy._typing import ArrayLike, DTypeLike, _DTypeLike, _SupportsDType as _HasDType
 
@@ -29,6 +41,7 @@ __all__ = [
 _T = TypeVar("_T")
 _DTypeT = TypeVar("_DTypeT", bound=np.dtype[Any])
 _ScalarT = TypeVar("_ScalarT", bound=np.generic)
+_ScalarT_co = TypeVar("_ScalarT_co", bound=np.generic, default=Any, covariant=True)
 _TupleT = TypeVar("_TupleT", bound=tuple[object, ...])
 _ArrayT = TypeVar("_ArrayT", bound=Array)
 
@@ -42,6 +55,52 @@ _Trans1DT_co = TypeVar("_Trans1DT_co", bound=int, default=L[-1], covariant=True)
 _Arrays: TypeAlias = tuple[Array[_ScalarT], ...]
 
 ###
+
+class ndenumerate(Generic[_ScalarT_co]):
+    @property
+    def iter(self) -> np.flatiter[Array[_ScalarT_co]]: ...
+
+    #
+    @overload
+    def __init__(self: ndenumerate[_ScalarT], /, arr: _ToArray1_nd[_ScalarT]) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.bytes_], /, arr: ToBytes_nd) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.str_], /, arr: ToStr_nd) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.bool], /, arr: ToBool_nd) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.intp], /, arr: ToIntP_nd) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.float64], /, arr: ToFloat64_nd) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.complex128], /, arr: ToComplex128_nd) -> None: ...
+    @overload
+    def __init__(self: ndenumerate[np.object_], /, arr: ToObject_nd) -> None: ...
+
+    # The first overload is a (semi-)workaround for a mypy bug (tested with v1.10 and v1.11)
+    @overload
+    def __next__(
+        self: ndenumerate[np.bool | np.number | np.flexible | np.datetime64 | np.timedelta64],
+        /,
+    ) -> tuple[tuple[int, ...], _ScalarT_co]: ...
+    @overload
+    def __next__(self: ndenumerate[np.object_], /) -> tuple[tuple[int, ...], Any]: ...
+    @overload
+    def __next__(self, /) -> tuple[tuple[int, ...], _ScalarT_co]: ...
+
+    #
+    def __iter__(self) -> Self: ...
+
+class ndindex:
+    @overload
+    def __init__(self, shape: tuple[SupportsIndex, ...], /) -> None: ...
+    @overload
+    def __init__(self, /, *shape: SupportsIndex) -> None: ...
+
+    #
+    def __iter__(self) -> Self: ...
+    def __next__(self) -> tuple[int, ...]: ...
 
 class nd_grid(Generic[_BoolT_co]):
     sparse: _BoolT_co

--- a/test/static/accept/index_tricks.pyi
+++ b/test/static/accept/index_tricks.pyi
@@ -1,3 +1,5 @@
+from decimal import Decimal
+from fractions import Fraction
 from types import EllipsisType
 from typing import Any
 from typing_extensions import assert_type
@@ -9,7 +11,7 @@ AR_LIKE_b: list[bool]
 AR_LIKE_i: list[int]
 AR_LIKE_f: list[float]
 AR_LIKE_U: list[str]
-AR_LIKE_O: list[object]
+AR_LIKE_O: list[Decimal | Fraction]
 
 AR_i8: npt.NDArray[np.int64]
 AR_O: npt.NDArray[np.object_]


### PR DESCRIPTION
This also moves `ndenumerate` and `ndindex` from `__init__.pyi` to  `lib/_index_tricks_impl.pyi` in `numpy-stubs`.

---

closes #190
