### PR TITLE
👷 `add-trailing-comma` pre-commit hook and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 
@@ -22,28 +22,23 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - name: typos
-        uses: crate-ci/typos@master
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5.3.0
         with:
           enable-cache: true
           python-version: "3.13"
           version: latest
 
-      - name: ruff check
-        run: uv run ruff check --output-format=github
-
-      - name: ruff format --check
-        run: uv run ruff format --check
-
       - name: pytest
         run: uv run pytest
 
       - name: basedpyright
-        run: uv run basedpyright
+        run: uv run basedpyright --threads 3
 
       - name: mypy (src)
         run: uv run test/mypy.py src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,10 @@ repos:
 
       - id: ruff-format
         types_or: [python, pyi]
+
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.1.0
+    hooks:
+      - id: add-trailing-comma
+        types: [file]
+        types_or: [python, pyi]


### PR DESCRIPTION
Additionally, all pre-commit hooks will now be ran from the CI, including `ruff check` and `ruff format`