### PR TITLE
👷 split CI steps into (parallelizable) jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -18,27 +17,46 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4
 
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
 
-      - uses: astral-sh/setup-uv@v5.3.0
+      - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          python-version: "3.13"
-          version: latest
+          python-version: 3.13t
 
       - name: pytest
         run: uv run pytest
 
+  basedpyright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: 3.13t
+
       - name: basedpyright
-        run: uv run basedpyright --threads 2
+        run: uv run basedpyright
+
+  mypy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: 3.13t
 
       - name: unstub numpy
         run: uv run tool/unstub.py
@@ -46,7 +64,21 @@ jobs:
       - name: mypy
         run: >
           uv run --no-editable
-          mypy --explicit-package-bases .
+          mypy --explicit-package-bases test
+
+  stubtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: 3.13t
+
+      - name: unstub numpy
+        run: uv run tool/unstub.py
 
       - name: stubtest
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 1
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
 
   basedpyright:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
 
@@ -58,34 +58,35 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          python-version: 3.13t
+          python-version: 3.13
 
       - name: mypy
         run: >
-          uv run --no-group=orjson --no-group=numpy
+          uv run --no-group=numpy
           mypy --no-incremental test
 
   stubtest:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          python-version: 3.13t
+          python-version: 3.13
 
       - name: unstub numpy
         run: >
-          uv run --no-group=orjson
+          uv run --no-editable
           tool/unstub.py
 
       - name: stubtest
         run: >
-          uv run --no-group=orjson
+          uv run --no-editable
           stubtest
           --mypy-config-file=pyproject.toml
           --allowlist=.mypyignore
           --allowlist=.mypyignore-todo
+          --concise
           numpy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.13t
 
       - name: pytest
-        run: uv run pytest
+        run: uv run --no-group=orjson pytest
 
   basedpyright:
     runs-on: ubuntu-latest
@@ -45,7 +45,9 @@ jobs:
           python-version: 3.13t
 
       - name: basedpyright
-        run: uv run basedpyright
+        run: >
+          uv run --no-group=orjson
+          basedpyright
 
   mypy:
     runs-on: ubuntu-latest
@@ -58,13 +60,10 @@ jobs:
           enable-cache: true
           python-version: 3.13t
 
-      - name: unstub numpy
-        run: uv run tool/unstub.py
-
       - name: mypy
         run: >
-          uv run --no-editable
-          mypy --explicit-package-bases test
+          uv run --no-group=orjson --no-group=numpy
+          mypy --no-incremental test
 
   stubtest:
     runs-on: ubuntu-latest
@@ -78,11 +77,13 @@ jobs:
           python-version: 3.13t
 
       - name: unstub numpy
-        run: uv run tool/unstub.py
+        run: >
+          uv run --no-group=orjson
+          tool/unstub.py
 
       - name: stubtest
         run: >
-          uv run --no-editable
+          uv run --no-group=orjson
           stubtest
           --mypy-config-file=pyproject.toml
           --allowlist=.mypyignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: basedpyright
         run: >
           uv run --no-group=orjson
-          basedpyright
+          basedpyright --threads=2
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: basedpyright
         run: >
           uv run --no-group=orjson
-          basedpyright --threads=2
+          basedpyright --threads=3
 
   mypy:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,17 @@ dependencies = []
 
 
 [dependency-groups]
-numpy = ["numtype[numpy]"]
 dev = [
-    {include-group = "numpy"},
     "basedpyright>=1.28.0",
-    "mypy[faster-cache]>=1.15.0",
+    "mypy>=1.15.0",
     "pytest>=8.3.4",
     "ruff>=0.9.8",
 ]
+numpy = ["numtype[numpy]"]
+orjson = ["orjson>=3.10.15"]  # speeds up mypy cache, but is missing 3.13t wheels
+
+[tool.uv]
+default-groups = ["dev", "numpy", "orjson"]
 
 
 [tool.hatch.build]
@@ -81,6 +84,7 @@ packages = [
 [tool.mypy]
 python_version = "3.10"
 mypy_path = "src"
+explicit_package_bases = true
 
 pretty = false
 show_error_context = false

--- a/uv.lock
+++ b/uv.lock
@@ -79,11 +79,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
 ]
 
-[package.optional-dependencies]
-faster-cache = [
-    { name = "orjson" },
-]
-
 [[package]]
 name = "mypy-extensions"
 version = "1.0.0"
@@ -184,13 +179,15 @@ numpy = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
-    { name = "mypy", extra = ["faster-cache"] },
-    { name = "numtype", extra = ["numpy"] },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
 ]
 numpy = [
     { name = "numtype", extra = ["numpy"] },
+]
+orjson = [
+    { name = "orjson" },
 ]
 
 [package.metadata]
@@ -200,12 +197,12 @@ provides-extras = ["numpy"]
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.0" },
-    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
-    { name = "numtype", extras = ["numpy"] },
+    { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.9.8" },
 ]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
+orjson = [{ name = "orjson", specifier = ">=3.10.15" }]
 
 [[package]]
 name = "orjson"


### PR DESCRIPTION
the goal is to speed up the CI runs