### PR TITLE
🏷️ fix stubtest errors in `timedelta64` and `object_`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -63,9 +63,6 @@ numpy(\._core(\.(_multiarray_umath|multiarray|numeric|umath))?|\.matlib)?\.sqrt
 numpy(\._core(\.(_multiarray_umath|multiarray|numeric|umath))?|\.matlib)?\.cbrt
 numpy(\._core(\.(_multiarray_umath|multiarray|numeric|umath))?|\.matlib)?\.vec(dot|mat)
 
-numpy(\..+)?\.object_.__call__
-numpy(\..+)?\.timedelta64.__class_getitem__
-
 numpy(\._core(\.arrayprint|\.numeric)?|\.matlib)?\.array2string
 numpy(\._core(\.einsumfunc)?)?\.einsum_path
 numpy(\._core(\.memmap)?|\.matlib)?\.memmap\.__new__

--- a/src/numpy-stubs/__init__.pyi
+++ b/src/numpy-stubs/__init__.pyi
@@ -4332,7 +4332,7 @@ class bool(generic[_BoolItemT_co], Generic[_BoolItemT_co]):
 # NOTE: Because mypy has some long-standing bugs related to `__new__`, `object_` can't
 # be made generic.
 @final
-class object_(_RealMixin, generic):
+class object_(_RealMixin, generic[Any]):
     @overload
     def __new__(cls, nothing_to_see_here: None = None, /) -> None: ...  # type: ignore[misc]
     @overload
@@ -4351,6 +4351,7 @@ class object_(_RealMixin, generic):
     #
     def __init__(self, value: object = ..., /) -> None: ...
     def __hash__(self, /) -> int: ...
+    def __call__(self, /, *args: object, **kwargs: object) -> Any: ...
 
     if sys.version_info >= (3, 12):
         def __release_buffer__(self, buffer: memoryview, /) -> None: ...
@@ -6255,6 +6256,9 @@ class timedelta64(_IntegralMixin, generic[_TD64ItemT_co], Generic[_TD64ItemT_co]
     ) -> None: ...
     @overload
     def __init__(self, value: _ConvertibleToTD64, format: _TimeUnitSpec = ..., /) -> None: ...
+
+    # inherited at runtime from `signedinteger`
+    def __class_getitem__(cls, type_arg: type | object, /) -> GenericAlias: ...
 
     # NOTE: Only a limited number of units support conversion
     # to builtin scalar types: `Y`, `M`, `ns`, `ps`, `fs`, `as`


### PR DESCRIPTION
the following methods were missing according to stubtest:

- `numpy.object_.__call__` 
- `numpy.timedelta64.__class_getitem__`