### PR TITLE
🏷️ fix stubtest errors in `numpy.lib._function_base_impl`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -8,20 +8,16 @@ numpy(\..+)?\.floating.as_integer_ratio
 numpy(\..+)?\.complexfloating.__hash__
 numpy(\..+)?\.complexfloating.__complex__
 
+numpy(\.lib\._arraysetops_impl|\.matlib)?\.union1d
+numpy(\.lib\._arraysetops_impl|\.matlib)?\.unique_(all|counts|inverse|values)
+numpy(\.lib\._npyio_impl|\.matlib)?\.genfromtxt
+numpy(\.lib\._npyio_impl|\.matlib)?\.save
+numpy(\.lib\._nanfunctions_impl|\.matlib)?\.nan(median|percentile)
+numpy(\.lib\._twodim_base_impl)?\.tri(l|u)
+
 numpy(\._core(\.arrayprint|\.numeric)?|\.matlib)?\.array2string
 numpy(\._core(\.einsumfunc)?|\.matlib)?\.einsum_path
 numpy(\._core(\.memmap)?|\.matlib)?\.memmap\.__new__
-
-numpy(\.lib\._arraysetops_impl|\.matlib)?\.union1d
-numpy(\.lib\._arraysetops_impl|\.matlib)?\.unique_(all|counts|inverse|values)
-numpy(\.lib\._function_base_impl|\.matlib)?\.average
-numpy(\.lib\._function_base_impl|\.matlib)?\.corrcoef
-numpy(\.lib\._function_base_impl|\.matlib)?\.median
-numpy(\.lib\._npyio_impl|\.matlib)?\.genfromtxt
-numpy(\.lib\._npyio_impl|\.matlib)?\.save
-numpy(\.lib\._nanfunctions_impl)?\.nan(median|percentile)
-numpy(\.lib\._twodim_base_impl)?\.tri(l|u)
-
 numpy(\.matrixlib(\.defmatrix)?|\.matlib)?\.matrix\.__new__
 numpy(\.lib\._polynomial_impl|\.matlib)?\.poly1d\.integ
 numpy(\.lib\._index_tricks_impl|\.matlib)?\.ndindex\.ndincr
@@ -154,7 +150,6 @@ numpy.ma(.core)?.f?mod
 numpy.ma(.core)?.indices
 numpy.ma(.core)?.remainder
 numpy.ma(.core)?.squeeze
-numpy.ma(.extras)?.average
 numpy.ma.core.mask_rowcols
 numpy.ma.extras.MAxisConcatenator.concatenate
 numpy.ma.mrecords.fromtextfile
@@ -164,8 +159,6 @@ numpy.matlib.typing
 numpy.matlib.cdouble
 numpy.matlib.hanning
 numpy.matlib.in1d
-numpy.matlib.nanmedian
-numpy.matlib.nanpercentile
 numpy.matlib.split
 numpy.matlib.stack
 numpy.matlib.tri(l|u)

--- a/src/numpy-stubs/lib/_function_base_impl.pyi
+++ b/src/numpy-stubs/lib/_function_base_impl.pyi
@@ -219,7 +219,7 @@ def average(
     weights: CoFloat64_nd | None = None,
     returned: L[False] = False,
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> np.float64: ...
 @overload
 def average(
@@ -228,7 +228,7 @@ def average(
     weights: CoFloat64_nd | None,
     returned: L[True],
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType = ...,
 ) -> _2Tuple[np.float64]: ...
 @overload
 def average(
@@ -237,7 +237,7 @@ def average(
     weights: CoFloat64_nd | None = None,
     *,
     returned: L[True],
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.float64]: ...
 @overload
 def average(
@@ -246,7 +246,7 @@ def average(
     weights: CoFloating_nd | None = None,
     returned: L[False] = False,
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> np.floating: ...
 @overload
 def average(
@@ -255,7 +255,7 @@ def average(
     weights: CoFloating_nd | None,
     returned: L[True],
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.floating]: ...
 @overload
 def average(
@@ -264,7 +264,7 @@ def average(
     weights: CoFloating_nd | None = None,
     *,
     returned: L[True],
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.floating]: ...
 @overload
 def average(
@@ -273,7 +273,7 @@ def average(
     weights: CoComplex_nd | None = None,
     returned: L[False] = False,
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> np.complexfloating: ...
 @overload
 def average(
@@ -282,7 +282,7 @@ def average(
     weights: ToComplex_nd,
     returned: L[False] = False,
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> np.complexfloating: ...
 @overload
 def average(
@@ -291,7 +291,7 @@ def average(
     *,
     weights: ToComplex_nd,
     returned: L[False] = False,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> np.complexfloating: ...
 @overload
 def average(
@@ -300,7 +300,7 @@ def average(
     weights: CoComplex_nd | None,
     returned: L[True],
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.complexfloating]: ...
 @overload
 def average(
@@ -309,7 +309,7 @@ def average(
     weights: ToComplex_nd,
     returned: L[True],
     *,
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.complexfloating]: ...
 @overload
 def average(
@@ -318,7 +318,7 @@ def average(
     weights: CoComplex_nd | None = None,
     *,
     returned: L[True],
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.complexfloating]: ...
 @overload
 def average(
@@ -327,7 +327,7 @@ def average(
     *,
     weights: ToComplex_nd,
     returned: L[True],
-    keepdims: L[False] = False,
+    keepdims: _NoValueType | L[False] = ...,
 ) -> _2Tuple[np.complexfloating]: ...
 @overload
 def average(
@@ -336,7 +336,7 @@ def average(
     weights: CoComplex_nd | ToObject_nd | None = None,
     returned: L[False] = False,
     *,
-    keepdims: bool = False,
+    keepdims: _NoValueType | bool = ...,
 ) -> Any: ...
 @overload
 def average(
@@ -345,7 +345,7 @@ def average(
     weights: CoComplex_nd | ToObject_nd | None,
     returned: L[True],
     *,
-    keepdims: bool = False,
+    keepdims: _NoValueType | bool = ...,
 ) -> _2Tuple[Any]: ...
 @overload
 def average(
@@ -354,7 +354,7 @@ def average(
     weights: CoComplex_nd | ToObject_nd | None = None,
     *,
     returned: L[True],
-    keepdims: bool = False,
+    keepdims: _NoValueType | bool = ...,
 ) -> _2Tuple[Any]: ...
 
 #
@@ -630,44 +630,54 @@ def cov(
     dtype: DTypeLike,
 ) -> Array: ...
 
-# NOTE `bias` and `ddof` have been deprecated
+# NOTE `bias` and `ddof` are deprecated and ignored
 @overload
 def corrcoef(
-    m: CoFloating_1nd,
+    x: CoFloating_1nd,
     y: CoFloating_1nd | None = None,
     rowvar: bool = True,
+    bias: _NoValueType = ...,
+    ddof: _NoValueType = ...,
     *,
     dtype: None = None,
 ) -> Array[np.floating]: ...
 @overload
 def corrcoef(
-    m: ToComplex_1nd,
+    x: ToComplex_1nd,
     y: CoComplex_1nd | None = None,
     rowvar: bool = True,
+    bias: _NoValueType = ...,
+    ddof: _NoValueType = ...,
     *,
     dtype: None = None,
 ) -> Array[np.complexfloating]: ...
 @overload
 def corrcoef(
-    m: CoComplex_1nd,
+    x: CoComplex_1nd,
     y: ToComplex_1nd,
     rowvar: bool = True,
+    bias: _NoValueType = ...,
+    ddof: _NoValueType = ...,
     *,
     dtype: None = None,
 ) -> Array[np.complexfloating]: ...
 @overload
 def corrcoef(
-    m: CoComplex_1nd,
+    x: CoComplex_1nd,
     y: CoComplex_1nd | None = None,
     rowvar: bool = True,
+    bias: _NoValueType = ...,
+    ddof: _NoValueType = ...,
     *,
     dtype: _DTypeLike[_ScalarT],
 ) -> Array[_ScalarT]: ...
 @overload
 def corrcoef(
-    m: CoComplex_1nd,
+    x: CoComplex_1nd,
     y: CoComplex_1nd | None = None,
     rowvar: bool = True,
+    bias: _NoValueType = ...,
+    ddof: _NoValueType = ...,
     *,
     dtype: DTypeLike | None = None,
 ) -> Array: ...
@@ -736,7 +746,6 @@ def median(
     a: CoComplex_nd | CoTimeDelta_nd | ToObject_nd,
     axis: _ShapeLike | None,
     out: _ArrayT,
-    /,
     overwrite_input: bool = False,
     keepdims: bool = False,
 ) -> _ArrayT: ...
@@ -1145,3 +1154,5 @@ def append(arr: ArrayLike, values: ArrayLike, axis: SupportsIndex | None = ...) 
 def digitize(x: CoFloating_0d, bins: CoFloating_1d, right: bool = False) -> np.intp: ...
 @overload
 def digitize(x: CoFloating_1nd, bins: CoFloating_1d, right: bool = False) -> Array[np.intp]: ...
+@overload
+def digitize(x: CoFloating_nd, bins: CoFloating_1d, right: bool = False) -> np.intp | Array[np.intp]: ...

--- a/src/numpy-stubs/ma/extras.pyi
+++ b/src/numpy-stubs/ma/extras.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Incomplete
 from typing import Final
 
+from numpy.lib._function_base_impl import average
 from numpy.lib._index_tricks_impl import AxisConcatenator
 
 from .core import dot, mask_rowcols
@@ -91,13 +92,6 @@ def apply_along_axis(
     **kwargs: Incomplete,
 ) -> Incomplete: ...
 def apply_over_axes(func: Incomplete, a: Incomplete, axes: Incomplete) -> Incomplete: ...
-def average(
-    a: Incomplete,
-    axis: Incomplete = ...,
-    weights: Incomplete = ...,
-    returned: Incomplete = ...,
-    keepdims: Incomplete = ...,
-) -> Incomplete: ...
 def median(
     a: Incomplete,
     axis: Incomplete = ...,

--- a/test/static/reject/lib_function_base.pyi
+++ b/test/static/reject/lib_function_base.pyi
@@ -43,8 +43,8 @@ np.cov(AR_O)  # type: ignore[arg-type]  # pyright: ignore[reportCallIssue,report
 
 np.corrcoef(AR_m)  # type: ignore[arg-type]  # pyright: ignore[reportCallIssue,reportArgumentType]
 np.corrcoef(AR_O)  # type: ignore[arg-type]  # pyright: ignore[reportCallIssue,reportArgumentType]
-np.corrcoef(AR_f8, bias=True)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue]
-np.corrcoef(AR_f8, ddof=2)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue]
+np.corrcoef(AR_f8, bias=True)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue, reportArgumentType]
+np.corrcoef(AR_f8, ddof=2)  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue, reportArgumentType]
 
 np.blackman(1j)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 np.bartlett(1j)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
This fixes the signatures of the following public `numpy` members:

- `average`
- `ma.average`
- `median`
- `corrcoef`