### PR TITLE
🏷️ fix stubtest errors in `numpy._core._type_aliases`

### DIFF
--- a/.mypyignore-todo
+++ b/.mypyignore-todo
@@ -16,15 +16,6 @@ numpy(\._core(\.memmap)?|\.matlib)?\.memmap\.__new__
 numpy(\.matrixlib(\.defmatrix)?|\.matlib)?\.matrix\.__new__
 numpy(\.lib\._polynomial_impl|\.matlib)?\.poly1d\.integ
 
-numpy._core._type_aliases.is_complex
-numpy._core._type_aliases.full_name
-numpy._core._type_aliases.abstract_type
-numpy._core._type_aliases.sctype_key
-numpy._core._type_aliases.type_group
-numpy._core._type_aliases.type_info
-numpy._core._type_aliases.k
-numpy._core._type_aliases.v
-
 numpy(\._?core(\.records)?|\.matlib|\.rec)?\.recarray\.__getattr__
 numpy(\._?core(\.records)?|\.matlib|\.rec)?\.recarray\.__new__
 numpy(\._?core(\.records)?|\.matlib|\.rec)?\.record\.__name__

--- a/src/numpy-stubs/_core/_type_aliases.pyi
+++ b/src/numpy-stubs/_core/_type_aliases.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Collection
-from typing import Final, Literal as L, TypeAlias, TypedDict, type_check_only
+from typing import Any, Final, Literal as L, TypeAlias, TypedDict, type_check_only
 
 import numpy as np
 
@@ -86,9 +86,18 @@ _abstract_type_names: Final[set[_AbstractTypeName]] = ...
 _aliases: Final[_AliasesType] = ...
 _extra_aliases: Final[_ExtraAliasesType] = ...
 
-concrete_type: type[np.generic]  # undocumented
-longdouble_type: type[np.longdouble | np.clongdouble]  # undocumented
-bits: int  # undocumented
-base_name: L["float", "complex"]  # undocumented
-extended_prec_name: L["float96", "float128", "complex192", "complex256"]  # undocumented
-sctype_list: list[type[np.generic]]  # undocumented
+# namespace pollution
+k: str
+v: str
+is_complex: bool
+full_name: str
+longdouble_type: type[np.longdouble | np.clongdouble]
+bits: int
+base_name: str
+extended_prec_name: str
+type_info: np.dtype[Any]
+type_group: str
+concrete_type: type[np.generic]
+abstract_type: type[np.generic]
+sctype_key: str
+sctype_list: list[type[np.generic]]


### PR DESCRIPTION
all stubtest errors were caused by namespace pollution, so this is more of a workaround to please stubtest than something that's actually useful