### PR TITLE
🏷️ stub `numpy._pyinstaller.hooks-numpy`

### DIFF
--- a/src/numpy-stubs/_pyinstaller/hook-numpy.pyi
+++ b/src/numpy-stubs/_pyinstaller/hook-numpy.pyi
@@ -1,0 +1,13 @@
+from typing import Final
+
+# from `PyInstaller.compat`
+is_conda: Final[bool]
+is_pure_conda: Final[bool]
+
+# from `PyInstaller.utils.hooks`
+def is_module_satisfies(requirements: str, version: None = None, version_attr: None = None) -> bool: ...
+
+binaries: Final[list[tuple[str, str]]]
+
+hiddenimports: Final[list[str]]
+excludedimports: Final[list[str]]

--- a/tool/.mypyignore-todo
+++ b/tool/.mypyignore-todo
@@ -8,8 +8,6 @@ numpy(\..+)?\.floating.as_integer_ratio
 numpy(\..+)?\.complexfloating.__hash__
 numpy(\..+)?\.complexfloating.__complex__
 
-numpy._pyinstaller.hook-numpy
-
 numpy.distutils
 
 numpy.f2py.__main__


### PR DESCRIPTION
closes #45