### PR TITLE
Don't swallow stderr output

### DIFF
--- a/tool/stubtest.py
+++ b/tool/stubtest.py
@@ -128,6 +128,7 @@ def main() -> int:
         capture_output=True,
         env={"FORCE_COLOR": "1"} | os.environ,
     )
+    sys.stderr.buffer.write(result.stderr)
     output = _rewrite_mypy_output(result.stdout)
     sys.stdout.buffer.write(output)
     sys.stdout.buffer.flush()


### PR DESCRIPTION
cc @jorenham 

I was looking into https://github.com/python/mypy/pull/18756#issuecomment-2702314731

It looks like the pre-release version of mypy crashes (for some reason related to property changes, will investigate). Crash logs are emitted to stderr and process exits with exit code 2.

This code does correctly chain the exit code, but swallows stderr.