### PR TITLE
🤡 also apply the `unittest.TestCase` workaround to `numpy.testing.TestCase`

### DIFF
--- a/src/numpy-stubs/ma/testutils.pyi
+++ b/src/numpy-stubs/ma/testutils.pyi
@@ -1,8 +1,6 @@
-from unittest import TestCase as _TestCase
-
 import numpy as np
 import numpy.typing as npt
-from numpy.testing import assert_, assert_allclose, assert_array_almost_equal_nulp, assert_raises
+from numpy.testing import TestCase, assert_, assert_allclose, assert_array_almost_equal_nulp, assert_raises
 from numpy.testing._private.utils import _ComparisonFunc
 
 __all__ = [
@@ -66,6 +64,3 @@ def assert_mask_equal(m1: object, m2: object, err_msg: str = "") -> None: ...
 
 assert_not_equal = fail_if_equal
 assert_close = assert_almost_equal
-
-class TestCase(_TestCase):
-    def __init_subclass__(cls, *args: object, **kwargs: object) -> None: ...

--- a/src/numpy-stubs/testing/__init__.pyi
+++ b/src/numpy-stubs/testing/__init__.pyi
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase as _TestCase
 
 from . import overrides
 from ._private.utils import (
@@ -100,3 +100,7 @@ __all__ = [
     "temppath",
     "verbose",
 ]
+
+# workaround for incorrect typeshed definition
+class TestCase(_TestCase):
+    def __init_subclass__(cls, *args: object, **kwargs: object) -> None: ...

--- a/test/static/accept/testing.pyi
+++ b/test/static/accept/testing.pyi
@@ -190,5 +190,3 @@ assert_type(np.testing.assert_no_gc_cycles(), contextlib._GeneratorContextManage
 assert_type(np.testing.assert_no_gc_cycles(func3, 5), None)
 
 assert_type(np.testing.break_cycles(), None)
-
-assert_type(np.testing.TestCase(), unittest.case.TestCase)

--- a/tool/.mypyignore.txt
+++ b/tool/.mypyignore.txt
@@ -32,4 +32,3 @@ numpy\.testing(\._private\.utils)?\.check_support_sve
 
 # stdlib re-exports with incorrect typeshed stubs
 numpy\.compat(\.py3k)?\.os_PathLike\.__class_getitem__
-numpy\.testing\.TestCase\.__init_subclass__


### PR DESCRIPTION
this also applies the `unittest.TestCase` workaround from #280 (applied in #281) to `numpy.testing.TestCase`

cc @guan404ming 