### PR TITLE
🔨 ufunc signature introspection script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,14 +50,17 @@ dev = [
     "mypy>=1.15.0",
     "pytest>=8.3.5",
     "ruff>=0.11.0",
-    "types-setuptools>=76.0.0.20250313",
 ]
 numpy = ["numtype[numpy]"]
 orjson = ["orjson>=3.10.15"] # speeds up mypy cache, but is missing 3.13t wheels
+types = [
+    "types-setuptools>=76.0.0.20250313",
+    "types-tabulate>=0.9.0.20241207",
+]
 
 
 [tool.uv]
-default-groups = ["dev", "numpy", "orjson"]
+default-groups = ["dev", "numpy", "orjson", "types"]
 
 
 [tool.hatch.build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,7 @@ env_list = ["ruff", "pytest", "basedpyright", "basedmypy", "3.13", "3.12", "3.11
 
 
 [tool.typos.default]
-extend-ignore-identifiers-re = ['ND|nd']
+extend-ignore-identifiers-re = ['ND|nd|nin|NIN']
 
 [tool.typos.files]
 extend-exclude = ["*.pyi", ".mypyignore"]

--- a/tool/ruff.toml
+++ b/tool/ruff.toml
@@ -3,6 +3,7 @@ line-length = 88
 
 [lint]
 extend-ignore = [
+    "TD003", # flake8-todos:    missing-todo-link
     "S101",  # flake8-bandit:   assert
     "S404",  # flake8-bandit:   suspicious-subprocess-import
     "S603",  # flake8-bandit:   subprocess-without-shell-equals-true

--- a/tool/ufunc.py
+++ b/tool/ufunc.py
@@ -1,0 +1,230 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "numtype[numpy]",
+#     "tabulate",
+# ]
+#
+# [tool.uv.sources]
+# numtype = {path = ".."}
+# ///
+
+"""
+UFunc introspection tools.
+
+Usage: uv run tool/ufunc.py [-h] [-p] [-f <TABULATE_FORMAT>] <NIN> <NOUT>
+"""
+
+import argparse
+import itertools
+import sys
+from collections.abc import Sequence
+from functools import cache
+from typing import Any, Final, TypeAlias
+
+import tabulate  # pyright: ignore[reportMissingModuleSource]
+
+import numpy as np
+import numpy._core.umath as um  # noqa: PLC2701
+
+_ScalarLike: TypeAlias = np.generic | np.ndarray[tuple[()], np.dtype[Any]]
+
+_EXTRA_SCALARS: Final[tuple[_ScalarLike, ...]] = (
+    np.str_(""),
+    np.array("", dtype="T"),
+    np.bytes_(b""),
+    np.void(b""),
+)
+
+
+@cache
+def _qualname(u: np.ufunc, /) -> str:
+    name = u.__name__
+    if hasattr(u, "__module__"):
+        return f"{u.__module__}.{name}"
+    if hasattr(np, name) and isinstance(getattr(np, name), np.ufunc):
+        return f"numpy.{name}"
+    if hasattr(np.strings, name) and isinstance(getattr(np.strings, name), np.ufunc):
+        return f"numpy.strings.{name}"
+    if hasattr(np.linalg._umath_linalg, name):  # type: ignore[attr-defined]  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportAttributeAccessIssue]  # noqa: SLF001
+        return f"numpy.linalg._umath_linalg.{name}"
+    if hasattr(um, name):
+        return f"numpy._core.umath.{name}"
+    raise NameError(u.__name__)
+
+
+@cache
+def _all_types(u: np.ufunc) -> tuple[str, ...]:
+    """Return all supported ufunc type signatures, including unlisted `'SUVT'` ones.
+
+    Returns
+    -------
+    extra_types : list of string-like type signatures
+    """
+    extra_types: list[str] = []
+
+    # ugly workaround for weird string ufuncs in `_core.umath`
+    prod_args = [_EXTRA_SCALARS] * u.nin
+    if u.nin > 1 and not u.types and _qualname(u).startswith("numpy._"):
+        prod_args = [
+            (np.longlong(0), np.longlong(1), *_EXTRA_SCALARS),
+        ] * u.nin
+
+    for args in itertools.product(*prod_args):
+        try:
+            vouts = u(*args)
+        except (ValueError, TypeError):
+            continue
+
+        tin = "".join(v.dtype.char for v in args)
+
+        tout = ""
+        if u.nout == 1:
+            vouts = (vouts,)
+        for vout in vouts:
+            if type(vout) is str:
+                tout += "T"
+            else:
+                char = vout.dtype.char
+                # avoid system dependent return types for `NPY_DEFAULT_INT`
+                tout += "n" if char == np.dtype("n").char else char
+
+        extra_types.append(f"{tin}->{tout}")
+
+    return tuple(dict.fromkeys(u.types + extra_types))
+
+
+def _unzip_types(
+    u: np.ufunc,
+    /,
+    *,
+    unique: bool = False,
+) -> tuple[tuple[list[str], ...], tuple[list[str], ...]]:
+    tinss: tuple[list[str], ...] = tuple([] for _ in range(u.nin))
+    toutss: tuple[list[str], ...] = tuple([] for _ in range(u.nout))
+
+    for t in dict.fromkeys(_all_types(u)):
+        for targss, targs_str in zip((tinss, toutss), t.split("->"), strict=True):
+            for targs, targ in zip(targss, targs_str, strict=True):
+                targs.append(targ)
+
+    if unique:
+        tinss = tuple(list(dict.fromkeys(tins)) for tins in tinss)
+        toutss = tuple(list(dict.fromkeys(touts)) for touts in toutss)
+
+    return tinss, toutss
+
+
+def _ufunc_list(
+    *,
+    nin: int | None = None,
+    nout: int | None = None,
+    private: bool = False,
+) -> list[dict[str, str]]:
+    def _sort_key(ufunc: np.ufunc, /) -> tuple[Any, ...]:
+        tins, touts = _unzip_types(ufunc, unique=True)
+        return (
+            _qualname(ufunc).count("."),
+            _qualname(ufunc).split(".", 1)[0],
+            ufunc.nin,
+            ufunc.nout,
+            tuple(map(len, touts)),
+            tuple(map(len, tins)),
+            "".join(_all_types(ufunc)),
+            _qualname(ufunc),
+        )
+
+    out: list[dict[str, str]] = []
+    for u in sorted(np.testing.overrides.get_overridable_numpy_ufuncs(), key=_sort_key):
+        if nin is not None and u.nin != nin:
+            continue
+        if nout is not None and u.nout != nout:
+            continue
+        if not private and u.__name__.startswith("_"):
+            continue
+
+        out.append(entry := {"name": _qualname(u).replace("numpy.", "")})
+
+        for param, n, targss in zip(
+            ("arg", "out"),
+            (nin, nout),
+            _unzip_types(u, unique=True),
+            strict=True,
+        ):
+            if n is not None and len(targss) == 1:
+                entry[param] = "".join(targss[0])
+            else:
+                for i, targs in enumerate(targss):
+                    entry[f"{param}{i}"] = (
+                        "".join(targs).replace("Tq", "qT").replace("TU", "UT")
+                    )
+
+    return out
+
+
+def _parse_args(args: Sequence[str] | None, /) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="ufunc.py")
+
+    parser.add_argument("nin", type=int, help="filter by `ufunc.nin`")
+    parser.add_argument("nout", type=int, help="filter by `ufunc.nout")
+    parser.add_argument(
+        "-p",
+        "--private",
+        action="store_true",
+        required=False,
+        help="show private ufuncs",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        choices=sorted(tabulate.tabulate_formats),
+        default="github",
+        help="output table format",
+    )
+
+    return parser.parse_args(args)
+
+
+def main(args: Sequence[str] | None = None, /) -> int:
+    """
+    Run it.
+
+    Returns
+    -------
+    exit_code : int
+    """
+    namespace = _parse_args(args)
+
+    data = _ufunc_list(
+        nin=namespace.nin,
+        nout=namespace.nout,
+        private=namespace.private,
+    )
+
+    match namespace.format:
+        case "github":
+            as_code = "`{}`".format
+        case "rst":
+            as_code = "``{}``".format
+        case _:
+            as_code = "{}".format
+
+    if data:
+        print(
+            tabulate.tabulate(
+                [list(map(as_code, entry.values())) for entry in data],
+                headers=[as_code("ufunc")] + list(map(as_code, data[0]))[1:],
+                tablefmt=namespace.format,
+            )
+            # needed for consistent ordering of string-like types
+            .replace("TS", "ST")
+            .replace("TV", "VT")
+            .replace("US", "SU"),
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tool/ufunc.py
+++ b/tool/ufunc.py
@@ -46,7 +46,7 @@ def _qualname(u: np.ufunc, /) -> str:
         return f"numpy.{name}"
     if hasattr(np.strings, name) and isinstance(getattr(np.strings, name), np.ufunc):
         return f"numpy.strings.{name}"
-    if hasattr(np.linalg._umath_linalg, name):  # type: ignore[attr-defined]  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportAttributeAccessIssue]  # noqa: SLF001
+    if hasattr(np.linalg._umath_linalg, name):  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType,reportAttributeAccessIssue]  # noqa: SLF001
         return f"numpy.linalg._umath_linalg.{name}"
     if hasattr(um, name):
         return f"numpy._core.umath.{name}"

--- a/tool/ufunc.py.lock
+++ b/tool/ufunc.py.lock
@@ -1,0 +1,108 @@
+version = 1
+revision = 1
+requires-python = ">=3.10"
+
+[manifest]
+requirements = [
+    { name = "numtype", extras = ["numpy"], directory = "../" },
+    { name = "tabulate" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/78/31103410a57bc2c2b93a3597340a8119588571f6a4539067546cb9a0bfac/numpy-2.2.4.tar.gz", hash = "sha256:9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f", size = 20270701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/89/a79e86e5c1433926ed7d60cb267fb64aa578b6101ab645800fd43b4801de/numpy-2.2.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8146f3550d627252269ac42ae660281d673eb6f8b32f113538e0cc2a9aed42b9", size = 21250661 },
+    { url = "https://files.pythonhosted.org/packages/79/c2/f50921beb8afd60ed9589ad880332cfefdb805422210d327fb48f12b7a81/numpy-2.2.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e642d86b8f956098b564a45e6f6ce68a22c2c97a04f5acd3f221f57b8cb850ae", size = 14389926 },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/2c4e96130b0b0f97b0ef4a06d6dae3b39d058b21a5e2fa2decd7fd6b1c8f/numpy-2.2.4-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:a84eda42bd12edc36eb5b53bbcc9b406820d3353f1994b6cfe453a33ff101775", size = 5428329 },
+    { url = "https://files.pythonhosted.org/packages/7f/a5/3d7094aa898f4fc5c84cdfb26beeae780352d43f5d8bdec966c4393d644c/numpy-2.2.4-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:4ba5054787e89c59c593a4169830ab362ac2bee8a969249dc56e5d7d20ff8df9", size = 6963559 },
+    { url = "https://files.pythonhosted.org/packages/4c/22/fb1be710a14434c09080dd4a0acc08939f612ec02efcb04b9e210474782d/numpy-2.2.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7716e4a9b7af82c06a2543c53ca476fa0b57e4d760481273e09da04b74ee6ee2", size = 14368066 },
+    { url = "https://files.pythonhosted.org/packages/c2/07/2e5cc71193e3ef3a219ffcf6ca4858e46ea2be09c026ddd480d596b32867/numpy-2.2.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adf8c1d66f432ce577d0197dceaac2ac00c0759f573f28516246351c58a85020", size = 16417040 },
+    { url = "https://files.pythonhosted.org/packages/1a/97/3b1537776ad9a6d1a41813818343745e8dd928a2916d4c9edcd9a8af1dac/numpy-2.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:218f061d2faa73621fa23d6359442b0fc658d5b9a70801373625d958259eaca3", size = 15879862 },
+    { url = "https://files.pythonhosted.org/packages/b0/b7/4472f603dd45ef36ff3d8e84e84fe02d9467c78f92cc121633dce6da307b/numpy-2.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:df2f57871a96bbc1b69733cd4c51dc33bea66146b8c63cacbfed73eec0883017", size = 18206032 },
+    { url = "https://files.pythonhosted.org/packages/0d/bd/6a092963fb82e6c5aa0d0440635827bbb2910da229545473bbb58c537ed3/numpy-2.2.4-cp310-cp310-win32.whl", hash = "sha256:a0258ad1f44f138b791327961caedffbf9612bfa504ab9597157806faa95194a", size = 6608517 },
+    { url = "https://files.pythonhosted.org/packages/01/e3/cb04627bc2a1638948bc13e818df26495aa18e20d5be1ed95ab2b10b6847/numpy-2.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:0d54974f9cf14acf49c60f0f7f4084b6579d24d439453d5fc5805d46a165b542", size = 12943498 },
+    { url = "https://files.pythonhosted.org/packages/16/fb/09e778ee3a8ea0d4dc8329cca0a9c9e65fed847d08e37eba74cb7ed4b252/numpy-2.2.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e9e0a277bb2eb5d8a7407e14688b85fd8ad628ee4e0c7930415687b6564207a4", size = 21254989 },
+    { url = "https://files.pythonhosted.org/packages/a2/0a/1212befdbecab5d80eca3cde47d304cad986ad4eec7d85a42e0b6d2cc2ef/numpy-2.2.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9eeea959168ea555e556b8188da5fa7831e21d91ce031e95ce23747b7609f8a4", size = 14425910 },
+    { url = "https://files.pythonhosted.org/packages/2b/3e/e7247c1d4f15086bb106c8d43c925b0b2ea20270224f5186fa48d4fb5cbd/numpy-2.2.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:bd3ad3b0a40e713fc68f99ecfd07124195333f1e689387c180813f0e94309d6f", size = 5426490 },
+    { url = "https://files.pythonhosted.org/packages/5d/fa/aa7cd6be51419b894c5787a8a93c3302a1ed4f82d35beb0613ec15bdd0e2/numpy-2.2.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cf28633d64294969c019c6df4ff37f5698e8326db68cc2b66576a51fad634880", size = 6967754 },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/96457c943265de9fadeb3d2ffdbab003f7fba13d971084a9876affcda095/numpy-2.2.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fa8fa7697ad1646b5c93de1719965844e004fcad23c91228aca1cf0800044a1", size = 14373079 },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/ceefca458559f0ccc7a982319f37ed07b0d7b526964ae6cc61f8ad1b6119/numpy-2.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4162988a360a29af158aeb4a2f4f09ffed6a969c9776f8f3bdee9b06a8ab7e5", size = 16428819 },
+    { url = "https://files.pythonhosted.org/packages/22/31/9b2ac8eee99e001eb6add9fa27514ef5e9faf176169057a12860af52704c/numpy-2.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:892c10d6a73e0f14935c31229e03325a7b3093fafd6ce0af704be7f894d95687", size = 15881470 },
+    { url = "https://files.pythonhosted.org/packages/f0/dc/8569b5f25ff30484b555ad8a3f537e0225d091abec386c9420cf5f7a2976/numpy-2.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db1f1c22173ac1c58db249ae48aa7ead29f534b9a948bc56828337aa84a32ed6", size = 18218144 },
+    { url = "https://files.pythonhosted.org/packages/5e/05/463c023a39bdeb9bb43a99e7dee2c664cb68d5bb87d14f92482b9f6011cc/numpy-2.2.4-cp311-cp311-win32.whl", hash = "sha256:ea2bb7e2ae9e37d96835b3576a4fa4b3a97592fbea8ef7c3587078b0068b8f09", size = 6606368 },
+    { url = "https://files.pythonhosted.org/packages/8b/72/10c1d2d82101c468a28adc35de6c77b308f288cfd0b88e1070f15b98e00c/numpy-2.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:f7de08cbe5551911886d1ab60de58448c6df0f67d9feb7d1fb21e9875ef95e91", size = 12947526 },
+    { url = "https://files.pythonhosted.org/packages/a2/30/182db21d4f2a95904cec1a6f779479ea1ac07c0647f064dea454ec650c42/numpy-2.2.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a7b9084668aa0f64e64bd00d27ba5146ef1c3a8835f3bd912e7a9e01326804c4", size = 20947156 },
+    { url = "https://files.pythonhosted.org/packages/24/6d/9483566acfbda6c62c6bc74b6e981c777229d2af93c8eb2469b26ac1b7bc/numpy-2.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dbe512c511956b893d2dacd007d955a3f03d555ae05cfa3ff1c1ff6df8851854", size = 14133092 },
+    { url = "https://files.pythonhosted.org/packages/27/f6/dba8a258acbf9d2bed2525cdcbb9493ef9bae5199d7a9cb92ee7e9b2aea6/numpy-2.2.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:bb649f8b207ab07caebba230d851b579a3c8711a851d29efe15008e31bb4de24", size = 5163515 },
+    { url = "https://files.pythonhosted.org/packages/62/30/82116199d1c249446723c68f2c9da40d7f062551036f50b8c4caa42ae252/numpy-2.2.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:f34dc300df798742b3d06515aa2a0aee20941c13579d7a2f2e10af01ae4901ee", size = 6696558 },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/54122b3c6df5df3e87582b2e9430f1bdb63af4023c739ba300164c9ae503/numpy-2.2.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f7ac96b16955634e223b579a3e5798df59007ca43e8d451a0e6a50f6bfdfba", size = 14084742 },
+    { url = "https://files.pythonhosted.org/packages/02/e2/e2cbb8d634151aab9528ef7b8bab52ee4ab10e076509285602c2a3a686e0/numpy-2.2.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f92084defa704deadd4e0a5ab1dc52d8ac9e8a8ef617f3fbb853e79b0ea3592", size = 16134051 },
+    { url = "https://files.pythonhosted.org/packages/8e/21/efd47800e4affc993e8be50c1b768de038363dd88865920439ef7b422c60/numpy-2.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4e84a6283b36632e2a5b56e121961f6542ab886bc9e12f8f9818b3c266bfbb", size = 15578972 },
+    { url = "https://files.pythonhosted.org/packages/04/1e/f8bb88f6157045dd5d9b27ccf433d016981032690969aa5c19e332b138c0/numpy-2.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:11c43995255eb4127115956495f43e9343736edb7fcdb0d973defd9de14cd84f", size = 17898106 },
+    { url = "https://files.pythonhosted.org/packages/2b/93/df59a5a3897c1f036ae8ff845e45f4081bb06943039ae28a3c1c7c780f22/numpy-2.2.4-cp312-cp312-win32.whl", hash = "sha256:65ef3468b53269eb5fdb3a5c09508c032b793da03251d5f8722b1194f1790c00", size = 6311190 },
+    { url = "https://files.pythonhosted.org/packages/46/69/8c4f928741c2a8efa255fdc7e9097527c6dc4e4df147e3cadc5d9357ce85/numpy-2.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:2aad3c17ed2ff455b8eaafe06bcdae0062a1db77cb99f4b9cbb5f4ecb13c5146", size = 12644305 },
+    { url = "https://files.pythonhosted.org/packages/2a/d0/bd5ad792e78017f5decfb2ecc947422a3669a34f775679a76317af671ffc/numpy-2.2.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cf4e5c6a278d620dee9ddeb487dc6a860f9b199eadeecc567f777daace1e9e7", size = 20933623 },
+    { url = "https://files.pythonhosted.org/packages/c3/bc/2b3545766337b95409868f8e62053135bdc7fa2ce630aba983a2aa60b559/numpy-2.2.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1974afec0b479e50438fc3648974268f972e2d908ddb6d7fb634598cdb8260a0", size = 14148681 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/67b24d68a56551d43a6ec9fe8c5f91b526d4c1a46a6387b956bf2d64744e/numpy-2.2.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:79bd5f0a02aa16808fcbc79a9a376a147cc1045f7dfe44c6e7d53fa8b8a79392", size = 5148759 },
+    { url = "https://files.pythonhosted.org/packages/1c/8b/e2fc8a75fcb7be12d90b31477c9356c0cbb44abce7ffb36be39a0017afad/numpy-2.2.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:3387dd7232804b341165cedcb90694565a6015433ee076c6754775e85d86f1fc", size = 6683092 },
+    { url = "https://files.pythonhosted.org/packages/13/73/41b7b27f169ecf368b52533edb72e56a133f9e86256e809e169362553b49/numpy-2.2.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f527d8fdb0286fd2fd97a2a96c6be17ba4232da346931d967a0630050dfd298", size = 14081422 },
+    { url = "https://files.pythonhosted.org/packages/4b/04/e208ff3ae3ddfbafc05910f89546382f15a3f10186b1f56bd99f159689c2/numpy-2.2.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bce43e386c16898b91e162e5baaad90c4b06f9dcbe36282490032cec98dc8ae7", size = 16132202 },
+    { url = "https://files.pythonhosted.org/packages/fe/bc/2218160574d862d5e55f803d88ddcad88beff94791f9c5f86d67bd8fbf1c/numpy-2.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31504f970f563d99f71a3512d0c01a645b692b12a63630d6aafa0939e52361e6", size = 15573131 },
+    { url = "https://files.pythonhosted.org/packages/a5/78/97c775bc4f05abc8a8426436b7cb1be806a02a2994b195945600855e3a25/numpy-2.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:81413336ef121a6ba746892fad881a83351ee3e1e4011f52e97fba79233611fd", size = 17894270 },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/38c06217a5f6de27dcb41524ca95a44e395e6a1decdc0c99fec0832ce6ae/numpy-2.2.4-cp313-cp313-win32.whl", hash = "sha256:f486038e44caa08dbd97275a9a35a283a8f1d2f0ee60ac260a1790e76660833c", size = 6308141 },
+    { url = "https://files.pythonhosted.org/packages/52/17/d0dd10ab6d125c6d11ffb6dfa3423c3571befab8358d4f85cd4471964fcd/numpy-2.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:207a2b8441cc8b6a2a78c9ddc64d00d20c303d79fba08c577752f080c4007ee3", size = 12636885 },
+    { url = "https://files.pythonhosted.org/packages/fa/e2/793288ede17a0fdc921172916efb40f3cbc2aa97e76c5c84aba6dc7e8747/numpy-2.2.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8120575cb4882318c791f839a4fd66161a6fa46f3f0a5e613071aae35b5dd8f8", size = 20961829 },
+    { url = "https://files.pythonhosted.org/packages/3a/75/bb4573f6c462afd1ea5cbedcc362fe3e9bdbcc57aefd37c681be1155fbaa/numpy-2.2.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a761ba0fa886a7bb33c6c8f6f20213735cb19642c580a931c625ee377ee8bd39", size = 14161419 },
+    { url = "https://files.pythonhosted.org/packages/03/68/07b4cd01090ca46c7a336958b413cdbe75002286295f2addea767b7f16c9/numpy-2.2.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:ac0280f1ba4a4bfff363a99a6aceed4f8e123f8a9b234c89140f5e894e452ecd", size = 5196414 },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/d4a29478d622fedff5c4b4b4cedfc37a00691079623c0575978d2446db9e/numpy-2.2.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:879cf3a9a2b53a4672a168c21375166171bc3932b7e21f622201811c43cdd3b0", size = 6709379 },
+    { url = "https://files.pythonhosted.org/packages/41/78/96dddb75bb9be730b87c72f30ffdd62611aba234e4e460576a068c98eff6/numpy-2.2.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f05d4198c1bacc9124018109c5fba2f3201dbe7ab6e92ff100494f236209c960", size = 14051725 },
+    { url = "https://files.pythonhosted.org/packages/00/06/5306b8199bffac2a29d9119c11f457f6c7d41115a335b78d3f86fad4dbe8/numpy-2.2.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2f085ce2e813a50dfd0e01fbfc0c12bbe5d2063d99f8b29da30e544fb6483b8", size = 16101638 },
+    { url = "https://files.pythonhosted.org/packages/fa/03/74c5b631ee1ded596945c12027649e6344614144369fd3ec1aaced782882/numpy-2.2.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:92bda934a791c01d6d9d8e038363c50918ef7c40601552a58ac84c9613a665bc", size = 15571717 },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/4fc7c0283abe0981e3b89f9b332a134e237dd476b0c018e1e21083310c31/numpy-2.2.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ee4d528022f4c5ff67332469e10efe06a267e32f4067dc76bb7e2cddf3cd25ff", size = 17879998 },
+    { url = "https://files.pythonhosted.org/packages/e5/2b/878576190c5cfa29ed896b518cc516aecc7c98a919e20706c12480465f43/numpy-2.2.4-cp313-cp313t-win32.whl", hash = "sha256:05c076d531e9998e7e694c36e8b349969c56eadd2cdcd07242958489d79a7286", size = 6366896 },
+    { url = "https://files.pythonhosted.org/packages/3e/05/eb7eec66b95cf697f08c754ef26c3549d03ebd682819f794cb039574a0a6/numpy-2.2.4-cp313-cp313t-win_amd64.whl", hash = "sha256:188dcbca89834cc2e14eb2f106c96d6d46f200fe0200310fc29089657379c58d", size = 12739119 },
+    { url = "https://files.pythonhosted.org/packages/b2/5c/f09c33a511aff41a098e6ef3498465d95f6360621034a3d95f47edbc9119/numpy-2.2.4-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7051ee569db5fbac144335e0f3b9c2337e0c8d5c9fee015f259a5bd70772b7e8", size = 21081956 },
+    { url = "https://files.pythonhosted.org/packages/ba/30/74c48b3b6494c4b820b7fa1781d441e94d87a08daa5b35d222f06ba41a6f/numpy-2.2.4-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:ab2939cd5bec30a7430cbdb2287b63151b77cf9624de0532d629c9a1c59b1d5c", size = 6827143 },
+    { url = "https://files.pythonhosted.org/packages/54/f5/ab0d2f48b490535c7a80e05da4a98902b632369efc04f0e47bb31ca97d8f/numpy-2.2.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0f35b19894a9e08639fd60a1ec1978cb7f5f7f1eace62f38dd36be8aecdef4d", size = 16233350 },
+    { url = "https://files.pythonhosted.org/packages/3b/3a/2f6d8c1f8e45d496bca6baaec93208035faeb40d5735c25afac092ec9a12/numpy-2.2.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b4adfbbc64014976d2f91084915ca4e626fbf2057fb81af209c1a6d776d23e3d", size = 12857565 },
+]
+
+[[package]]
+name = "numtype"
+version = "2.2.4.0.dev0"
+source = { directory = "../" }
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2.2.4,<2.3" }]
+provides-extras = ["numpy"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright", specifier = ">=1.28.1" },
+    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.0" },
+]
+numpy = [{ name = "numtype", extras = ["numpy"] }]
+orjson = [{ name = "orjson", specifier = ">=3.10.15" }]
+types = [
+    { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252 },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -182,13 +182,16 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
-    { name = "types-setuptools" },
 ]
 numpy = [
     { name = "numtype", extra = ["numpy"] },
 ]
 orjson = [
     { name = "orjson" },
+]
+types = [
+    { name = "types-setuptools" },
+    { name = "types-tabulate" },
 ]
 
 [package.metadata]
@@ -201,10 +204,13 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.0" },
-    { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
 ]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
 orjson = [{ name = "orjson", specifier = ">=3.10.15" }]
+types = [
+    { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 
 [[package]]
 name = "orjson"
@@ -328,11 +334,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "76.0.0"
+version = "76.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/32/d2/7b171caf085ba0d40d8391f54e1c75a1cda9255f542becf84575cfd8a732/setuptools-76.0.0.tar.gz", hash = "sha256:43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4", size = 1349387 }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2b/287ade3a580869e6178cb37d045f54272b1f006f2c0ff6fad08db258d027/setuptools-76.1.0.tar.gz", hash = "sha256:4959b9ad482ada2ba2320c8f1a8d8481d4d8d668908a7a1b84d987375cd7f5bd", size = 1350273 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/66/d2d7e6ad554f3a7c7297c3f8ef6e22643ad3d35ef5c63bf488bc89f32f31/setuptools-76.0.0-py3-none-any.whl", hash = "sha256:199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6", size = 1236106 },
+    { url = "https://files.pythonhosted.org/packages/62/fb/47dc84839f2743553075c80d08543b3d0f498f42329141b6717504abcdfd/setuptools-76.1.0-py3-none-any.whl", hash = "sha256:34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73", size = 1236933 },
 ]
 
 [[package]]
@@ -384,6 +390,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b8/0f/2d1d000c2be3919bcdea15e5da48456bf1e55c18d02c5509ea59dade1408/types_setuptools-76.0.0.20250313.tar.gz", hash = "sha256:b2be66f550f95f3cad2a7d46177b273c7e9c80df7d257fa57addbbcfc8126a9e", size = 43627 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/89/ea9669a0a76b160ffb312d0b02b15bad053c1bc81d2a54e42e3a402ca754/types_setuptools-76.0.0.20250313-py3-none-any.whl", hash = "sha256:bf454b2a49b8cfd7ebcf5844d4dd5fe4c8666782df1e3663c5866fd51a47460e", size = 65845 },
+]
+
+[[package]]
+name = "types-tabulate"
+version = "0.9.0.20241207"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/43/16030404a327e4ff8c692f2273854019ed36718667b2993609dc37d14dd4/types_tabulate-0.9.0.20241207.tar.gz", hash = "sha256:ac1ac174750c0a385dfd248edc6279fa328aaf4ea317915ab879a2ec47833230", size = 8195 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/86/a9ebfd509cbe74471106dffed320e208c72537f9aeb0a55eaa6b1b5e4d17/types_tabulate-0.9.0.20241207-py3-none-any.whl", hash = "sha256:b8dad1343c2a8ba5861c5441370c3e35908edd234ff036d4298708a1d4cf8a85", size = 8307 },
 ]
 
 [[package]]


### PR DESCRIPTION
The ufuncs that support string-like input never seem to include those signatures in their `ufunc.types`. This script automatically figures these out. It  can only list the aggregates input/output types (including the string-like ones) at the moment. But it could easily be extended to display more information about e.g. a specific ufunc signature. It could perhaps even be turned into an automatic ufunc signature code generator, or "just" an exhaustive type-test generator for ufuncs.

This script has been used to generate the following overview (respost from https://github.com/numpy/numtype/issues/230#issuecomment-2734958282):

---

# Summary of NumPy ufunc signatures

This includes the supported `SUVT` signatures that, for some reason, are never listed in `ufunc.types`.

This only includes the *overridable* (through `__array_ufunc__`) ufuncs, i.e. the gufuncs are not included.

These tables were generated with `tool/ufunc.py`.

## 1 in, 1 out

| `ufunc`                          | `arg`                   | `out`                   |
|----------------------------------|-------------------------|-------------------------|
| `isnat`                          | `Mm`                    | `?`                     |
| `signbit`                        | `efdg`                  | `?`                     |
| `isfinite`                       | `?bBhHiIlLqQefdgFDGmM`  | `?`                     |
| `isinf`                          | `?bBhHiIlLqQefdgFDGmM`  | `?`                     |
| `isnan`                          | `?bBhHiIlLqQefdgFDGmMT` | `?`                     |
| `bitwise_count`                  | `bBhHiIlLqQO`           | `BO`                    |
| `logical_not`                    | `?bBhHiIlLqQefdgFDGO`   | `?O`                    |
| `spacing`                        | `efdg`                  | `efdg`                  |
| `cbrt`                           | `efdgO`                 | `efdgO`                 |
| `deg2rad`                        | `efdgO`                 | `efdgO`                 |
| `degrees`                        | `efdgO`                 | `efdgO`                 |
| `fabs`                           | `efdgO`                 | `efdgO`                 |
| `rad2deg`                        | `efdgO`                 | `efdgO`                 |
| `radians`                        | `efdgO`                 | `efdgO`                 |
| `arccos`                         | `efdgFDGO`              | `efdgFDGO`              |
| `arccosh`                        | `efdgFDGO`              | `efdgFDGO`              |
| `arcsin`                         | `efdgFDGO`              | `efdgFDGO`              |
| `arcsinh`                        | `efdgFDGO`              | `efdgFDGO`              |
| `arctan`                         | `efdgFDGO`              | `efdgFDGO`              |
| `arctanh`                        | `efdgFDGO`              | `efdgFDGO`              |
| `cos`                            | `efdgFDGO`              | `efdgFDGO`              |
| `cosh`                           | `efdgFDGO`              | `efdgFDGO`              |
| `exp`                            | `efdgFDGO`              | `efdgFDGO`              |
| `exp2`                           | `efdgFDGO`              | `efdgFDGO`              |
| `expm1`                          | `efdgFDGO`              | `efdgFDGO`              |
| `log`                            | `efdgFDGO`              | `efdgFDGO`              |
| `log10`                          | `efdgFDGO`              | `efdgFDGO`              |
| `log1p`                          | `efdgFDGO`              | `efdgFDGO`              |
| `log2`                           | `efdgFDGO`              | `efdgFDGO`              |
| `rint`                           | `efdgFDGO`              | `efdgFDGO`              |
| `sin`                            | `efdgFDGO`              | `efdgFDGO`              |
| `sinh`                           | `efdgFDGO`              | `efdgFDGO`              |
| `sqrt`                           | `efdgFDGO`              | `efdgFDGO`              |
| `tan`                            | `efdgFDGO`              | `efdgFDGO`              |
| `tanh`                           | `efdgFDGO`              | `efdgFDGO`              |
| `invert`                         | `?bBhHiIlLqQO`          | `?bBhHiIlLqQO`          |
| `ceil`                           | `?bBhHiIlLqQefdgO`      | `?bBhHiIlLqQefdgO`      |
| `floor`                          | `?bBhHiIlLqQefdgO`      | `?bBhHiIlLqQefdgO`      |
| `trunc`                          | `?bBhHiIlLqQefdgO`      | `?bBhHiIlLqQefdgO`      |
| `absolute`                       | `?bBhHiIlLqQefdgmFDGO`  | `?bBhHiIlLqQefdgmO`     |
| `conjugate`                      | `bBhHiIlLqQefdgFDGO`    | `bBhHiIlLqQefdgFDGO`    |
| `reciprocal`                     | `bBhHiIlLqQefdgFDGO`    | `bBhHiIlLqQefdgFDGO`    |
| `square`                         | `bBhHiIlLqQefdgFDGO`    | `bBhHiIlLqQefdgFDGO`    |
| `sign`                           | `bBhHiIlLqQefdgFDGmO`   | `bBhHiIlLqQefdgFDGmO`   |
| `negative`                       | `bBhHiIlLqQefdgmFDGO`   | `bBhHiIlLqQefdgmFDGO`   |
| `positive`                       | `bBhHiIlLqQefdgmFDGO`   | `bBhHiIlLqQefdgmFDGO`   |
| `strings.isdecimal`              | `UT`                    | `?`                     |
| `strings.isnumeric`              | `UT`                    | `?`                     |
| `strings.isalnum`                | `SUT`                   | `?`                     |
| `strings.isalpha`                | `SUT`                   | `?`                     |
| `strings.isdigit`                | `SUT`                   | `?`                     |
| `strings.islower`                | `SUT`                   | `?`                     |
| `strings.isspace`                | `SUT`                   | `?`                     |
| `strings.istitle`                | `SUT`                   | `?`                     |
| `strings.isupper`                | `SUT`                   | `?`                     |
| `strings.str_len`                | `SUT`                   | `n`                     |
| `_core.umath._lstrip_whitespace` | `SUT`                   | `SUT`                   |
| `_core.umath._rstrip_whitespace` | `SUT`                   | `SUT`                   |
| `_core.umath._strip_whitespace`  | `SUT`                   | `SUT`                   |
| `_core.umath._ones_like`         | `?bBhHiIlLqQefdgFDGmMO` | `?bBhHiIlLqQefdgFDGmMO` |

## 1 in, 2 out

| `ufunc`   | `arg`   | `out0`   | `out1`   |
|-----------|---------|----------|----------|
| `frexp`   | `efdg`  | `efdg`   | `i`      |
| `modf`    | `efdg`  | `efdg`   | `efdg`   |

## 2 in, 1 out

| `ufunc`                          | `arg0`                     | `arg1`                     | `out`                      |
|----------------------------------|----------------------------|----------------------------|----------------------------|
| `logical_and`                    | `?bBhHiIlLqQefdgFDGOSUVT`  | `?bBhHiIlLqQefdgFDGOSUVT`  | `?O`                       |
| `logical_or`                     | `?bBhHiIlLqQefdgFDGOSUVT`  | `?bBhHiIlLqQefdgFDGOSUVT`  | `?O`                       |
| `logical_xor`                    | `?bBhHiIlLqQefdgFDGOSUVT`  | `?bBhHiIlLqQefdgFDGOSUVT`  | `?O`                       |
| `equal`                          | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` | `?O`                       |
| `greater`                        | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` | `?O`                       |
| `greater_equal`                  | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` | `?O`                       |
| `less`                           | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` | `?O`                       |
| `less_equal`                     | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` | `?O`                       |
| `not_equal`                      | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` | `?O`                       |
| `ldexp`                          | `efdg`                     | `il`                       | `efdg`                     |
| `float_power`                    | `dgDG`                     | `dgDG`                     | `dgDG`                     |
| `copysign`                       | `efdg`                     | `efdg`                     | `efdg`                     |
| `heaviside`                      | `efdg`                     | `efdg`                     | `efdg`                     |
| `logaddexp`                      | `efdg`                     | `efdg`                     | `efdg`                     |
| `logaddexp2`                     | `efdg`                     | `efdg`                     | `efdg`                     |
| `nextafter`                      | `efdg`                     | `efdg`                     | `efdg`                     |
| `arctan2`                        | `efdgO`                    | `efdgO`                    | `efdgO`                    |
| `hypot`                          | `efdgO`                    | `efdgO`                    | `efdgO`                    |
| `divide`                         | `efdgFDGmO`                | `efdgFDGqmO`               | `efdgFDGmO`                |
| `gcd`                            | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              |
| `lcm`                            | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              |
| `left_shift`                     | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              |
| `right_shift`                    | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              | `bBhHiIlLqQO`              |
| `bitwise_and`                    | `?bBhHiIlLqQO`             | `?bBhHiIlLqQO`             | `?bBhHiIlLqQO`             |
| `bitwise_or`                     | `?bBhHiIlLqQO`             | `?bBhHiIlLqQO`             | `?bBhHiIlLqQO`             |
| `bitwise_xor`                    | `?bBhHiIlLqQO`             | `?bBhHiIlLqQO`             | `?bBhHiIlLqQO`             |
| `fmod`                           | `bBhHiIlLqQefdgO`          | `bBhHiIlLqQefdgO`          | `bBhHiIlLqQefdgO`          |
| `remainder`                      | `bBhHiIlLqQefdgmO`         | `bBhHiIlLqQefdgmO`         | `bBhHiIlLqQefdgmO`         |
| `floor_divide`                   | `bBhHiIlLqQefdgmO`         | `bBhHiIlLqQefdgmO`         | `bBhHiIlLqQefdgmO`         |
| `power`                          | `bBhHiIlLqQefdgFDGO`       | `bBhHiIlLqQefdgFDGO`       | `bBhHiIlLqQefdgFDGO`       |
| `matmul`                         | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      |
| `matvec`                         | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      |
| `vecdot`                         | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      |
| `vecmat`                         | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      | `?bBhHiIlLqQefdgFDGO`      |
| `multiply`                       | `?bBhHiIlLqQefdgFDGmO`     | `?bBhHiIlLqQefdgFDGmO`     | `?bBhHiIlLqQefdgFDGmO`     |
| `subtract`                       | `bBhHiIlLqQefdgFDGMmO`     | `bBhHiIlLqQefdgFDGmMO`     | `bBhHiIlLqQefdgFDGMmO`     |
| `fmax`                           | `?bBhHiIlLqQefdgFDGmMO`    | `?bBhHiIlLqQefdgFDGmMO`    | `?bBhHiIlLqQefdgFDGmMO`    |
| `fmin`                           | `?bBhHiIlLqQefdgFDGmMO`    | `?bBhHiIlLqQefdgFDGmMO`    | `?bBhHiIlLqQefdgFDGmMO`    |
| `maximum`                        | `?bBhHiIlLqQefdgFDGmMOT`   | `?bBhHiIlLqQefdgFDGmMOT`   | `?bBhHiIlLqQefdgFDGmMOT`   |
| `minimum`                        | `?bBhHiIlLqQefdgFDGmMOT`   | `?bBhHiIlLqQefdgFDGmMOT`   | `?bBhHiIlLqQefdgFDGmMOT`   |
| `add`                            | `?bBhHiIlLqQefdgFDGMmOSUT` | `?bBhHiIlLqQefdgFDGmMOSUT` | `?bBhHiIlLqQefdgFDGMmOSUT` |

| `ufunc`                          | `arg0`                     | `arg1`                     | `out`                      |
|----------------------------------|----------------------------|----------------------------|----------------------------|
| `_core.umath._expandtabs`        | `T`                        | `q`                        | `T`                        |
| `_core.umath._zfill`             | `T`                        | `q`                        | `T`                        |
| `_core.umath._expandtabs_length` | `SU`                       | `q`                        | `n`                        |
| `_core.umath._lstrip_chars`      | `SUT`                      | `SUT`                      | `SUT`                      |
| `_core.umath._rstrip_chars`      | `SUT`                      | `SUT`                      | `SUT`                      |
| `_core.umath._strip_chars`       | `SUT`                      | `SUT`                      | `SUT`                      |

Note that the `_expandtabs[_length]` and `_zfill` ufuncs also accept `S` and `U` if `out` is set.

## 2 in, 2 out

| `ufunc`   | `arg0`            | `arg1`            | `out0`           | `out1`            |
|-----------|-------------------|-------------------|------------------|-------------------|
| `divmod`  | `bBhHiIlLqQefdgm` | `bBhHiIlLqQefdgm` | `bBhHiIlLqQefdg` | `bBhHiIlLqQefdgm` |

## 2 in, 3 out

| `ufunc`                   | `arg0`   | `arg1`   | `out0`   | `out1`   | `out2`   |
|---------------------------|----------|----------|----------|----------|----------|
| `_core.umath._partition`  | ``       | ``       | ``       | ``       | ``       |
| `_core.umath._rpartition` | ``       | ``       | ``       | ``       | ``       |

These require `out` to be set, and accept `SU`

## 3 in, 1 out

| `ufunc`               | `arg0`                  | `arg1`                  | `arg2`                  | `out`                   |
|-----------------------|-------------------------|-------------------------|-------------------------|-------------------------|
| `_core.umath._center` | `UT`                    | `q`                     | `qSUVT`                 | `T`                     |
| `_core.umath._ljust`  | `UT`                    | `q`                     | `qSUVT`                 | `T`                     |
| `_core.umath._rjust`  | `UT`                    | `q`                     | `qSUVT`                 | `T`                     |
| `_core.umath.clip`    | `?bBhHiIlLqQefdgFDGmMO` | `?bBhHiIlLqQefdgFDGmMO` | `?bBhHiIlLqQefdgFDGmMO` | `?bBhHiIlLqQefdgFDGmMO` |

## 3 in, 3 out

| `ufunc`                         | `arg0`   | `arg1`   | `arg2`   | `out0`   | `out1`   | `out2`   |
|---------------------------------|----------|----------|----------|----------|----------|----------|
| `_core.umath._partition_index`  | `SU`     | `SU`     | `q`      | `SU`     | `SU`     | `SU`    |
| `_core.umath._rpartition_index` | `SU`     | `SU`     | `q`      | `SU`     | `SU`     | `SU`    |

These require `out` to be set (to a 3-tuple of `str_ | bytes_` arrays)

## 4 in, 1 out

| `ufunc`                  | `arg0`   | `arg1`   | `arg2`   | `arg3`   | `out`   |
|--------------------------|----------|----------|----------|----------|---------|
| `_core.umath._replace`   | `UT`     | `UT`     | `UT`     | `q`      | `T`     |
| `_core.umath.endswith`   | `SUT`    | `SUT`    | `q`      | `q`      | `?`     |
| `_core.umath.startswith` | `SUT`    | `SUT`    | `q`      | `q`      | `?`     |
| `_core.umath.count`      | `SUT`    | `SUT`    | `q`      | `q`      | `n`     |
| `_core.umath.find`       | `SUT`    | `SUT`    | `q`      | `q`      | `n`     |
| `_core.umath.index`      | `SUT`    | `SUT`    | `q`      | `q`      | `n`     |
| `_core.umath.rfind`      | `SUT`    | `SUT`    | `q`      | `q`      | `n`     |
| `_core.umath.rindex`     | `SUT`    | `SUT`    | `q`      | `q`      | `n`     |