### PR TITLE
Changed duplicated fftfreq tests to rfftfreq.

### DIFF
--- a/test/static/accept/fft.pyi
+++ b/test/static/accept/fft.pyi
@@ -16,8 +16,8 @@ assert_type(np.fft.ifftshift(AR_LIKE_f8, axes=0), npt.NDArray[np.floating])
 assert_type(np.fft.fftfreq(5, AR_f8), npt.NDArray[np.floating])
 assert_type(np.fft.fftfreq(np.int64(), AR_c16), npt.NDArray[np.inexact])
 
-assert_type(np.fft.fftfreq(5, AR_f8), npt.NDArray[np.floating])
-assert_type(np.fft.fftfreq(np.int64(), AR_c16), npt.NDArray[np.inexact])
+assert_type(np.fft.rfftfreq(5, AR_f8), npt.NDArray[np.floating])
+assert_type(np.fft.rfftfreq(np.int64(), AR_c16), npt.NDArray[np.inexact])
 
 assert_type(np.fft.fft(AR_f8), npt.NDArray[np.complex128])
 assert_type(np.fft.ifft(AR_f8, axis=1), npt.NDArray[np.complex128])


### PR DESCRIPTION
Fixes typo in static tests for fft, in which `rfftfreq` was left untested and `fftfreq` was tested twice.

I was unable to run the mypy test, but the basedpyright test is still happy.