### PR TITLE
🧑‍💻 don't use schema's in the even-better-toml vscode plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   "evenBetterToml.formatter.indentString": "    ",
   "evenBetterToml.formatter.indentTables": true,
   "evenBetterToml.formatter.trailingNewline": true,
+  "evenBetterToml.schema.enabled": false,
   "files.readonlyInclude": {
     "**/generated/*.pyi": true
   },


### PR DESCRIPTION
closes #374

---

It is enabled by default, which causes false positives about incorrect schema definitions in `pyproject.toml`. I already had it globally disabled, but for it helps with DX to disable it in the project's vscode config as well.

cc @guan404ming