### PR TITLE
📦 reoganize development dependency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,18 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          python-version: 3.13t
+      - run: uv sync --only-group=list_and_test
 
       - name: ruff
         run: |
-          uv run --no-group=orjson ruff check --output-format=github
-          uv run --no-group=orjson ruff format --check
+          uv run --no-sync ruff check --output-format=github
+          uv run --no-sync ruff format --check
 
       - name: pytest
-        run: uv run --no-group=orjson pytest
+        run: uv run --no-sync pytest
 
       - name: format-ignores
-        run: uv run --no-group=orjson tool/format_ignores.py --check
+        run: uv run --no-sync tool/format_ignores.py --check
 
   basedpyright:
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
           python-version: ${{ matrix.py }}
 
       - name: basedpyright
-        run: uv run --no-group=orjson basedpyright
+        run: uv run --only-group=basedpyright basedpyright
 
   mypy:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
 
       - name: mypy
         run: >
-          uv run --no-group=numpy
+          uv run --only-group=mypy --no-editable
           mypy --no-incremental --cache-dir=/dev/null --soft-error-limit=-1 .
 
   stubtest:
@@ -114,5 +114,5 @@ jobs:
 
       - name: stubtest
         run: >
-          uv run --active -p ${{ matrix.py }}
+          uv run --no-dev --active -p ${{ matrix.py }}
           tool/stubtest.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,5 @@
   },
   "git.branchProtection": ["main"],
   "markdownlint.configFile": "docs/.markdownlint.yaml",
-  "mypy-type-checker.path": ["uv", "run", "mypy"]
+  "mypy-type-checker.path": ["uv", "run", "--no-sync", "mypy"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,18 +49,34 @@ dependencies = []
 
 
 [dependency-groups]
-dev = [
-    "basedpyright>=1.28.4",
-    "mdformat>=0.7.22",
-    "mypy>=1.15.0",
-    "pytest>=8.3.5",
+numpy = ["numtype[numpy]"]
+types = [
+    "types-setuptools>=78.1.0.20250329",
+    "types-tabulate>=0.9.0.20241207",
+]
+lint = [
     "ruff>=0.11.2",
 ]
-numpy = ["numtype[numpy]"]
-orjson = ["orjson>=3.10.16"] # speeds up mypy cache, but is missing 3.13t wheels
-types = [
-    "types-setuptools>=76.0.0.20250313",
-    "types-tabulate>=0.9.0.20241207",
+pytest = [
+    {include-group = "numpy"},
+    "pytest>=8.3.5",
+]
+list_and_test = [
+    {include-group = "lint"},
+    {include-group = "pytest"},
+]
+basedpyright = [
+    {include-group = "numpy"},
+    {include-group = "types"},
+    "basedpyright>=1.28.4",
+]
+mypy = [
+    {include-group = "types"},
+    "mypy[faster-cache]>=1.15.0",
+]
+typecheck = [
+    {include-group = "basedpyright"},
+    {include-group = "mypy"},
 ]
 docs = [
     "mkdocs-material>=9.6.9",
@@ -68,10 +84,11 @@ docs = [
     "mkdocs-minify-plugin>=0.8.0",
     "mkdocstrings[python]>=0.29.0",
 ]
-
-
-[tool.uv]
-default-groups = ["dev", "numpy", "orjson", "types"]
+dev = [
+    {include-group = "list_and_test"},
+    {include-group = "typecheck"},
+    {include-group = "docs"},
+]
 
 
 [tool.hatch.build]
@@ -95,11 +112,6 @@ packages = ["src/_numtype", "src/numtype", "src/numpy-stubs"]
 [tool.mypy]
 mypy_path = "src"
 explicit_package_bases = true
-
-pretty = false
-show_error_context = false
-show_error_code_links = false
-show_traceback = false
 
 strict = true
 strict_bytes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ lint = [
 pytest = [
     {include-group = "numpy"},
     "pytest>=8.3.5",
+    "typing_extensions>=4.13.0",
 ]
 list_and_test = [
     {include-group = "lint"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,7 @@ dependencies = []
 
 [dependency-groups]
 numpy = ["numtype[numpy]"]
-types = [
-    "types-setuptools>=78.1.0.20250329",
-    "types-tabulate>=0.9.0.20241207",
-]
-lint = [
-    "ruff>=0.11.2",
-]
+lint = ["ruff>=0.11.2"]
 pytest = [
     {include-group = "numpy"},
     "pytest>=8.3.5",
@@ -65,6 +59,11 @@ pytest = [
 list_and_test = [
     {include-group = "lint"},
     {include-group = "pytest"},
+]
+types = [
+    {include-group = "pytest"},
+    "types-setuptools>=78.1.0.20250329",
+    "types-tabulate>=0.9.0.20241207",
 ]
 basedpyright = [
     {include-group = "numpy"},

--- a/tool/stubtest.py.lock
+++ b/tool/stubtest.py.lock
@@ -50,16 +50,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.130.4"
+version = "6.130.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/3d/199be3124dac341deb47747354a9e9ae2fa69f644229b5f3d0705a680cfd/hypothesis-6.130.4.tar.gz", hash = "sha256:d0672eb0ac1060b0324b0e43925a50b2bef1c60a32739bb9233000d85838436a", size = 427602 }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/6e/e32a9c896ed621461fc7afcb0e7b61960247c2764d80c341d88ba14f45fa/hypothesis-6.130.5.tar.gz", hash = "sha256:2cdcdd894adc390a688c8a1c08580c345a67ecf73e31d5bb51a7712acf7b747c", size = 428116 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/d4/5a0c46cc8d266626cdc8082f07f836fa4a96e8715002de69be46ed406d1d/hypothesis-6.130.4-py3-none-any.whl", hash = "sha256:cda4a57115d10ecbefe0a9cc8d69d20a13eb56ecbfe7c24eaee5d368c2b7c477", size = 491324 },
+    { url = "https://files.pythonhosted.org/packages/99/84/318648e1a0c40aee9fe2140c0bbd507ecfa691bab16ba854bff479967dfe/hypothesis-6.130.5-py3-none-any.whl", hash = "sha256:c13e42ec7df7fdc45c44d0b39f1e429d2253e19a37041d927e092afa7645bfcf", size = 492048 },
 ]
 
 [[package]]
@@ -212,17 +212,56 @@ requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2
 provides-extras = ["numpy"]
 
 [package.metadata.requires-dev]
+basedpyright = [
+    { name = "basedpyright", specifier = ">=1.28.4" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.4" },
-    { name = "mdformat", specifier = ">=0.7.22" },
-    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-material", specifier = ">=9.6.9" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.2" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
+docs = [
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-material", specifier = ">=9.6.9" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+]
+lint = [{ name = "ruff", specifier = ">=0.11.2" }]
+list-and-test = [
+    { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
 ]
+mypy = [
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
-orjson = [{ name = "orjson", specifier = ">=3.10.16" }]
+pytest = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+]
+typecheck = [
+    { name = "basedpyright", specifier = ">=1.28.4" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 types = [
-    { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
 ]
 
@@ -441,14 +480,14 @@ wheels = [
 
 [[package]]
 name = "types-setuptools"
-version = "76.0.0.20250313"
+version = "78.1.0.20250329"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/0f/2d1d000c2be3919bcdea15e5da48456bf1e55c18d02c5509ea59dade1408/types_setuptools-76.0.0.20250313.tar.gz", hash = "sha256:b2be66f550f95f3cad2a7d46177b273c7e9c80df7d257fa57addbbcfc8126a9e", size = 43627 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/6e/c54e6705e5fe67c3606e4c7c91123ecf10d7e1e6d7a9c11b52970cf2196c/types_setuptools-78.1.0.20250329.tar.gz", hash = "sha256:31e62950c38b8cc1c5114b077504e36426860a064287cac11b9666ab3a483234", size = 43942 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/89/ea9669a0a76b160ffb312d0b02b15bad053c1bc81d2a54e42e3a402ca754/types_setuptools-76.0.0.20250313-py3-none-any.whl", hash = "sha256:bf454b2a49b8cfd7ebcf5844d4dd5fe4c8666782df1e3663c5866fd51a47460e", size = 65845 },
+    { url = "https://files.pythonhosted.org/packages/7d/31/85d0264705d8ef47680d28f4dc9bb1e27d8cace785fbe3f8d009fad6cb88/types_setuptools-78.1.0.20250329-py3-none-any.whl", hash = "sha256:ea47eab891afb506f470eee581dcde44d64dc99796665da794da6f83f50f6776", size = 66985 },
 ]
 
 [[package]]

--- a/tool/stubtest.py.lock
+++ b/tool/stubtest.py.lock
@@ -230,6 +230,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 docs = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
@@ -242,6 +243,7 @@ list-and-test = [
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 mypy = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
@@ -252,6 +254,7 @@ numpy = [{ name = "numtype", extras = ["numpy"] }]
 pytest = [
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 typecheck = [
     { name = "basedpyright", specifier = ">=1.28.4" },

--- a/tool/stubtest.py.lock
+++ b/tool/stubtest.py.lock
@@ -215,8 +215,10 @@ provides-extras = ["numpy"]
 basedpyright = [
     { name = "basedpyright", specifier = ">=1.28.4" },
     { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.4" },
@@ -247,8 +249,11 @@ list-and-test = [
 ]
 mypy = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
 pytest = [
@@ -260,12 +265,17 @@ typecheck = [
     { name = "basedpyright", specifier = ">=1.28.4" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
     { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 types = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 
 [[package]]

--- a/tool/ufunc.py.lock
+++ b/tool/ufunc.py.lock
@@ -88,8 +88,10 @@ provides-extras = ["numpy"]
 basedpyright = [
     { name = "basedpyright", specifier = ">=1.28.4" },
     { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.4" },
@@ -120,8 +122,11 @@ list-and-test = [
 ]
 mypy = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
 pytest = [
@@ -133,12 +138,17 @@ typecheck = [
     { name = "basedpyright", specifier = ">=1.28.4" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
     { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 types = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 
 [[package]]

--- a/tool/ufunc.py.lock
+++ b/tool/ufunc.py.lock
@@ -103,6 +103,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 docs = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
@@ -115,6 +116,7 @@ list-and-test = [
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 mypy = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
@@ -125,6 +127,7 @@ numpy = [{ name = "numtype", extras = ["numpy"] }]
 pytest = [
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 typecheck = [
     { name = "basedpyright", specifier = ">=1.28.4" },

--- a/tool/ufunc.py.lock
+++ b/tool/ufunc.py.lock
@@ -85,17 +85,56 @@ requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2
 provides-extras = ["numpy"]
 
 [package.metadata.requires-dev]
+basedpyright = [
+    { name = "basedpyright", specifier = ">=1.28.4" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.4" },
-    { name = "mdformat", specifier = ">=0.7.22" },
-    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-material", specifier = ">=9.6.9" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.2" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
+docs = [
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-material", specifier = ">=9.6.9" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+]
+lint = [{ name = "ruff", specifier = ">=0.11.2" }]
+list-and-test = [
+    { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
 ]
+mypy = [
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
-orjson = [{ name = "orjson", specifier = ">=3.10.16" }]
+pytest = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+]
+typecheck = [
+    { name = "basedpyright", specifier = ">=1.28.4" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 types = [
-    { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -165,14 +165,14 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.6.3"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/28/f61564ce1237727f0daa0b28e18201252e032aa7d7fb0e4fa0b447ecad4b/griffe-1.6.3.tar.gz", hash = "sha256:568cc9e50de04f6c76234bf46dd7f3a264ea3cbb1380fb54818e81e3675a83cf", size = 393810 }
+sdist = { url = "https://files.pythonhosted.org/packages/30/1b/fe7a3a33a2fb7ad7807f71957e6108a50d93271ab718d9a56080415f66de/griffe-1.7.1.tar.gz", hash = "sha256:464730d0e95d0afd038e699a5f7276d7438d0712db0c489a17e761f70e011507", size = 394522 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/11/46f2e6370ecf8e9e3ab01ad422fb9ea5b90579bdc4b1a8527aa745b20758/griffe-1.6.3-py3-none-any.whl", hash = "sha256:7a0c559f10d8a9016f4d0b4ceaacc087e31e2370cb1aa9a59006a30d5a279fb3", size = 128922 },
+    { url = "https://files.pythonhosted.org/packages/1d/94/48e28b1c7402f750200e9e3ef4834c862ea85c64f426a231a6dc312f61a9/griffe-1.7.1-py3-none-any.whl", hash = "sha256:37a7f15233937d723ddc969fa4117fdd03988885c16938dc43bccdfe8fa4d02d", size = 129134 },
 ]
 
 [[package]]
@@ -226,18 +226,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2", size = 357086 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803", size = 106349 },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
 ]
 
 [[package]]
@@ -296,28 +284,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
-]
-
-[[package]]
-name = "mdformat"
-version = "0.7.22"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447 },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
 [[package]]
@@ -515,6 +481,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
 ]
 
+[package.optional-dependencies]
+faster-cache = [
+    { name = "orjson" },
+]
+
 [[package]]
 name = "mypy-extensions"
 version = "1.0.0"
@@ -613,12 +584,24 @@ numpy = [
 ]
 
 [package.dev-dependencies]
+basedpyright = [
+    { name = "basedpyright" },
+    { name = "numtype", extra = ["numpy"] },
+    { name = "types-setuptools" },
+    { name = "types-tabulate" },
+]
 dev = [
     { name = "basedpyright" },
-    { name = "mdformat" },
-    { name = "mypy" },
+    { name = "mkdocs-include-markdown-plugin" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-minify-plugin" },
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mypy", extra = ["faster-cache"] },
+    { name = "numtype", extra = ["numpy"] },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-setuptools" },
+    { name = "types-tabulate" },
 ]
 docs = [
     { name = "mkdocs-include-markdown-plugin" },
@@ -626,11 +609,32 @@ docs = [
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+lint = [
+    { name = "ruff" },
+]
+list-and-test = [
+    { name = "numtype", extra = ["numpy"] },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+mypy = [
+    { name = "mypy", extra = ["faster-cache"] },
+    { name = "types-setuptools" },
+    { name = "types-tabulate" },
+]
 numpy = [
     { name = "numtype", extra = ["numpy"] },
 ]
-orjson = [
-    { name = "orjson" },
+pytest = [
+    { name = "numtype", extra = ["numpy"] },
+    { name = "pytest" },
+]
+typecheck = [
+    { name = "basedpyright" },
+    { name = "mypy", extra = ["faster-cache"] },
+    { name = "numtype", extra = ["numpy"] },
+    { name = "types-setuptools" },
+    { name = "types-tabulate" },
 ]
 types = [
     { name = "types-setuptools" },
@@ -642,12 +646,24 @@ requires-dist = [{ name = "numpy", marker = "extra == 'numpy'", specifier = ">=2
 provides-extras = ["numpy"]
 
 [package.metadata.requires-dev]
+basedpyright = [
+    { name = "basedpyright", specifier = ">=1.28.4" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.4" },
-    { name = "mdformat", specifier = ">=0.7.22" },
-    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
+    { name = "mkdocs-material", specifier = ">=9.6.9" },
+    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
 ]
 docs = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
@@ -655,10 +671,31 @@ docs = [
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
 ]
+lint = [{ name = "ruff", specifier = ">=0.11.2" }]
+list-and-test = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.2" },
+]
+mypy = [
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
-orjson = [{ name = "orjson", specifier = ">=3.10.16" }]
+pytest = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+]
+typecheck = [
+    { name = "basedpyright", specifier = ">=1.28.4" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
+    { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+]
 types = [
-    { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
+    { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
 ]
 
@@ -975,14 +1012,14 @@ wheels = [
 
 [[package]]
 name = "types-setuptools"
-version = "76.0.0.20250313"
+version = "78.1.0.20250329"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/0f/2d1d000c2be3919bcdea15e5da48456bf1e55c18d02c5509ea59dade1408/types_setuptools-76.0.0.20250313.tar.gz", hash = "sha256:b2be66f550f95f3cad2a7d46177b273c7e9c80df7d257fa57addbbcfc8126a9e", size = 43627 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/6e/c54e6705e5fe67c3606e4c7c91123ecf10d7e1e6d7a9c11b52970cf2196c/types_setuptools-78.1.0.20250329.tar.gz", hash = "sha256:31e62950c38b8cc1c5114b077504e36426860a064287cac11b9666ab3a483234", size = 43942 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/89/ea9669a0a76b160ffb312d0b02b15bad053c1bc81d2a54e42e3a402ca754/types_setuptools-76.0.0.20250313-py3-none-any.whl", hash = "sha256:bf454b2a49b8cfd7ebcf5844d4dd5fe4c8666782df1e3663c5866fd51a47460e", size = 65845 },
+    { url = "https://files.pythonhosted.org/packages/7d/31/85d0264705d8ef47680d28f4dc9bb1e27d8cace785fbe3f8d009fad6cb88/types_setuptools-78.1.0.20250329-py3-none-any.whl", hash = "sha256:ea47eab891afb506f470eee581dcde44d64dc99796665da794da6f83f50f6776", size = 66985 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -602,6 +602,7 @@ dev = [
     { name = "ruff" },
     { name = "types-setuptools" },
     { name = "types-tabulate" },
+    { name = "typing-extensions" },
 ]
 docs = [
     { name = "mkdocs-include-markdown-plugin" },
@@ -616,6 +617,7 @@ list-and-test = [
     { name = "numtype", extra = ["numpy"] },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "typing-extensions" },
 ]
 mypy = [
     { name = "mypy", extra = ["faster-cache"] },
@@ -628,6 +630,7 @@ numpy = [
 pytest = [
     { name = "numtype", extra = ["numpy"] },
     { name = "pytest" },
+    { name = "typing-extensions" },
 ]
 typecheck = [
     { name = "basedpyright" },
@@ -664,6 +667,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 docs = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.5" },
@@ -676,6 +680,7 @@ list-and-test = [
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 mypy = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
@@ -686,6 +691,7 @@ numpy = [{ name = "numtype", extras = ["numpy"] }]
 pytest = [
     { name = "numtype", extras = ["numpy"] },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 typecheck = [
     { name = "basedpyright", specifier = ">=1.28.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -587,8 +587,10 @@ numpy = [
 basedpyright = [
     { name = "basedpyright" },
     { name = "numtype", extra = ["numpy"] },
+    { name = "pytest" },
     { name = "types-setuptools" },
     { name = "types-tabulate" },
+    { name = "typing-extensions" },
 ]
 dev = [
     { name = "basedpyright" },
@@ -621,8 +623,11 @@ list-and-test = [
 ]
 mypy = [
     { name = "mypy", extra = ["faster-cache"] },
+    { name = "numtype", extra = ["numpy"] },
+    { name = "pytest" },
     { name = "types-setuptools" },
     { name = "types-tabulate" },
+    { name = "typing-extensions" },
 ]
 numpy = [
     { name = "numtype", extra = ["numpy"] },
@@ -636,12 +641,17 @@ typecheck = [
     { name = "basedpyright" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "numtype", extra = ["numpy"] },
+    { name = "pytest" },
     { name = "types-setuptools" },
     { name = "types-tabulate" },
+    { name = "typing-extensions" },
 ]
 types = [
+    { name = "numtype", extra = ["numpy"] },
+    { name = "pytest" },
     { name = "types-setuptools" },
     { name = "types-tabulate" },
+    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -652,8 +662,10 @@ provides-extras = ["numpy"]
 basedpyright = [
     { name = "basedpyright", specifier = ">=1.28.4" },
     { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 dev = [
     { name = "basedpyright", specifier = ">=1.28.4" },
@@ -684,8 +696,11 @@ list-and-test = [
 ]
 mypy = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 numpy = [{ name = "numtype", extras = ["numpy"] }]
 pytest = [
@@ -697,12 +712,17 @@ typecheck = [
     { name = "basedpyright", specifier = ">=1.28.4" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
     { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 types = [
+    { name = "numtype", extras = ["numpy"] },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-setuptools", specifier = ">=78.1.0.20250329" },
     { name = "types-tabulate", specifier = ">=0.9.0.20241207" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
This way we avoid installing unnecessary development dependencies in the CI steps.
The `docs` group is now also installed as a default development dependency.