### PR TITLE
👷 update dependabot configuration to allow all dependency types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,8 @@ updates:
     target-branch: main
     schedule:
       interval: daily
-    groups:
-      actions:
-        patterns:
-          - "*"
+    allow:
+      - dependency-type: "all"
     labels:
       - "topic: dependencies"
       - "tool: github-actions"
@@ -20,10 +18,8 @@ updates:
     target-branch: main
     schedule:
       interval: daily
-    groups:
-      actions:
-        patterns:
-          - "*"
+    allow:
+      - dependency-type: "all"
     ignore:
       - dependency-name: "numpy"
     labels:


### PR DESCRIPTION
Close #426 

Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#allow--