### PR TITLE
👷 add docs-check to `lefthook`

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,14 @@ pre-commit:
       glob: "*.{py,pyi}"
       run: uv run --no-sync tool/format_ignores.py {staged_files}
       stage_fixed: true
+    docs-check:
+      glob:
+        - "docs/**"
+        - "mkdocs.yml"
+        - ".github/workflows/docs.yml"
+        - "CONTRIBUTING.md"
+      run: uv run --no-sync mkdocs build
+      stage_fixed: true
 
 post-checkout:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,10 +17,8 @@ pre-commit:
       glob:
         - "docs/**"
         - "mkdocs.yml"
-        - ".github/workflows/docs.yml"
         - "CONTRIBUTING.md"
       run: uv run --no-sync mkdocs build
-      stage_fixed: true
 
 post-checkout:
   commands:


### PR DESCRIPTION
make the doc build be in the `lefthook` ensuring the build works normal in local