### PR TITLE
✨ statically embed nep-50 in the numeric scalar types

### DIFF
--- a/src/_numtype/@test/test_can_promote.pyi
+++ b/src/_numtype/@test/test_can_promote.pyi
@@ -1,0 +1,568 @@
+from typing import Any
+
+import numpy as np
+from _numtype._scalar_co import CanPromote
+
+b1: np.bool
+i1: np.int8
+i2: np.int16
+i4: np.int32
+i8: np.int64
+u1: np.uint8
+u2: np.uint16
+u4: np.uint32
+u8: np.uint64
+f2: np.float16
+f4: np.float32
+f8: np.float64
+ld: np.longdouble
+c8: np.complex64
+c16: np.complex128
+cld: np.clongdouble
+
+###
+# See https://numpy.org/neps/nep-0050-scalar-promotion.html
+
+b1_from_b1: CanPromote[np.bool] = b1
+b1_from_i1: CanPromote[np.bool] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_u1: CanPromote[np.bool] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_i2: CanPromote[np.bool] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_u2: CanPromote[np.bool] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_i4: CanPromote[np.bool] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_u4: CanPromote[np.bool] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_i8: CanPromote[np.bool] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_u8: CanPromote[np.bool] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_f2: CanPromote[np.bool] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_f4: CanPromote[np.bool] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_f8: CanPromote[np.bool] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_ld: CanPromote[np.bool] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_c8: CanPromote[np.bool] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_c16: CanPromote[np.bool] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+b1_from_cld: CanPromote[np.bool] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+b1_to_b1: CanPromote[Any, np.bool] = b1
+b1_to_i1: CanPromote[Any, np.bool] = i1
+b1_to_u1: CanPromote[Any, np.bool] = u1
+b1_to_i2: CanPromote[Any, np.bool] = i2
+b1_to_u2: CanPromote[Any, np.bool] = u2
+b1_to_i4: CanPromote[Any, np.bool] = i4
+b1_to_u4: CanPromote[Any, np.bool] = u4
+b1_to_i8: CanPromote[Any, np.bool] = i8
+b1_to_u8: CanPromote[Any, np.bool] = u8
+b1_to_f2: CanPromote[Any, np.bool] = f2
+b1_to_f4: CanPromote[Any, np.bool] = f4
+b1_to_f8: CanPromote[Any, np.bool] = f8
+b1_to_ld: CanPromote[Any, np.bool] = ld
+b1_to_c8: CanPromote[Any, np.bool] = c8
+b1_to_c16: CanPromote[Any, np.bool] = c16
+b1_to_cld: CanPromote[Any, np.bool] = cld
+
+i1_from_b1: CanPromote[np.int8] = b1
+i1_from_i1: CanPromote[np.int8] = i1
+i1_from_u1: CanPromote[np.int8] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_i2: CanPromote[np.int8] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_u2: CanPromote[np.int8] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_i4: CanPromote[np.int8] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_u4: CanPromote[np.int8] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_i8: CanPromote[np.int8] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_u8: CanPromote[np.int8] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_f2: CanPromote[np.int8] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_f4: CanPromote[np.int8] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_f8: CanPromote[np.int8] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_ld: CanPromote[np.int8] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_c8: CanPromote[np.int8] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_c16: CanPromote[np.int8] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_from_cld: CanPromote[np.int8] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+i1_to_b1: CanPromote[Any, np.int8] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_to_i1: CanPromote[Any, np.int8] = i1
+i1_to_u1: CanPromote[Any, np.int8] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_to_i2: CanPromote[Any, np.int8] = i2
+i1_to_u2: CanPromote[Any, np.int8] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_to_i4: CanPromote[Any, np.int8] = i4
+i1_to_u4: CanPromote[Any, np.int8] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_to_i8: CanPromote[Any, np.int8] = i8
+i1_to_u8: CanPromote[Any, np.int8] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i1_to_f2: CanPromote[Any, np.int8] = f2
+i1_to_f4: CanPromote[Any, np.int8] = f4
+i1_to_f8: CanPromote[Any, np.int8] = f8
+i1_to_ld: CanPromote[Any, np.int8] = ld
+i1_to_c8: CanPromote[Any, np.int8] = c8
+i1_to_c16: CanPromote[Any, np.int8] = c16
+i1_to_cld: CanPromote[Any, np.int8] = cld
+
+u1_from_b1: CanPromote[np.uint8] = b1
+u1_from_i1: CanPromote[np.uint8] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_u1: CanPromote[np.uint8] = u1
+u1_from_i2: CanPromote[np.uint8] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_u2: CanPromote[np.uint8] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_i4: CanPromote[np.uint8] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_u4: CanPromote[np.uint8] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_i8: CanPromote[np.uint8] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_u8: CanPromote[np.uint8] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_f2: CanPromote[np.uint8] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_f4: CanPromote[np.uint8] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_f8: CanPromote[np.uint8] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_ld: CanPromote[np.uint8] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_c8: CanPromote[np.uint8] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_c16: CanPromote[np.uint8] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_from_cld: CanPromote[np.uint8] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+u1_to_b1: CanPromote[Any, np.uint8] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_to_i1: CanPromote[Any, np.uint8] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u1_to_u1: CanPromote[Any, np.uint8] = u1
+u1_to_i2: CanPromote[Any, np.uint8] = i2
+u1_to_u2: CanPromote[Any, np.uint8] = u2
+u1_to_i4: CanPromote[Any, np.uint8] = i4
+u1_to_u4: CanPromote[Any, np.uint8] = u4
+u1_to_i8: CanPromote[Any, np.uint8] = i8
+u1_to_u8: CanPromote[Any, np.uint8] = u8
+u1_to_f2: CanPromote[Any, np.uint8] = f2
+u1_to_f4: CanPromote[Any, np.uint8] = f4
+u1_to_f8: CanPromote[Any, np.uint8] = f8
+u1_to_ld: CanPromote[Any, np.uint8] = ld
+u1_to_c8: CanPromote[Any, np.uint8] = c8
+u1_to_c16: CanPromote[Any, np.uint8] = c16
+u1_to_cld: CanPromote[Any, np.uint8] = cld
+
+i2_from_b1: CanPromote[np.int16] = b1
+i2_from_i1: CanPromote[np.int16] = i1
+i2_from_u1: CanPromote[np.int16] = u1
+i2_from_i2: CanPromote[np.int16] = i2
+i2_from_u2: CanPromote[np.int16] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_i4: CanPromote[np.int16] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_u4: CanPromote[np.int16] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_i8: CanPromote[np.int16] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_u8: CanPromote[np.int16] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_f2: CanPromote[np.int16] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_f4: CanPromote[np.int16] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_f8: CanPromote[np.int16] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_ld: CanPromote[np.int16] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_c8: CanPromote[np.int16] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_c16: CanPromote[np.int16] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_from_cld: CanPromote[np.int16] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+i2_to_b1: CanPromote[Any, np.int16] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_i1: CanPromote[Any, np.int16] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_u1: CanPromote[Any, np.int16] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_i2: CanPromote[Any, np.int16] = i2
+i2_to_u2: CanPromote[Any, np.int16] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_i4: CanPromote[Any, np.int16] = i4
+i2_to_u4: CanPromote[Any, np.int16] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_i8: CanPromote[Any, np.int16] = i8
+i2_to_u8: CanPromote[Any, np.int16] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_f2: CanPromote[Any, np.int16] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i2_to_f4: CanPromote[Any, np.int16] = f4
+i2_to_f8: CanPromote[Any, np.int16] = f8
+i2_to_ld: CanPromote[Any, np.int16] = ld
+i2_to_c8: CanPromote[Any, np.int16] = c8
+i2_to_c16: CanPromote[Any, np.int16] = c16
+i2_to_cld: CanPromote[Any, np.int16] = cld
+
+u2_from_b1: CanPromote[np.uint16] = b1
+u2_from_i1: CanPromote[np.uint16] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_u1: CanPromote[np.uint16] = u1
+u2_from_i2: CanPromote[np.uint16] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_u2: CanPromote[np.uint16] = u2
+u2_from_i4: CanPromote[np.uint16] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_u4: CanPromote[np.uint16] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_i8: CanPromote[np.uint16] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_u8: CanPromote[np.uint16] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_f2: CanPromote[np.uint16] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_f4: CanPromote[np.uint16] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_f8: CanPromote[np.uint16] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_ld: CanPromote[np.uint16] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_c8: CanPromote[np.uint16] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_c16: CanPromote[np.uint16] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_from_cld: CanPromote[np.uint16] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+u2_to_b1: CanPromote[Any, np.uint16] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_to_i1: CanPromote[Any, np.uint16] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_to_u1: CanPromote[Any, np.uint16] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_to_i2: CanPromote[Any, np.uint16] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_to_u2: CanPromote[Any, np.uint16] = u2
+u2_to_i4: CanPromote[Any, np.uint16] = i4
+u2_to_u4: CanPromote[Any, np.uint16] = u4
+u2_to_i8: CanPromote[Any, np.uint16] = i8
+u2_to_u8: CanPromote[Any, np.uint16] = u8
+u2_to_f2: CanPromote[Any, np.uint16] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u2_to_f4: CanPromote[Any, np.uint16] = f4
+u2_to_f8: CanPromote[Any, np.uint16] = f8
+u2_to_ld: CanPromote[Any, np.uint16] = ld
+u2_to_c8: CanPromote[Any, np.uint16] = c8
+u2_to_c16: CanPromote[Any, np.uint16] = c16
+u2_to_cld: CanPromote[Any, np.uint16] = cld
+
+i4_from_b1: CanPromote[np.int32] = b1
+i4_from_i1: CanPromote[np.int32] = i1
+i4_from_u1: CanPromote[np.int32] = u1
+i4_from_i2: CanPromote[np.int32] = i2
+i4_from_u2: CanPromote[np.int32] = u2
+i4_from_i4: CanPromote[np.int32] = i4
+i4_from_u4: CanPromote[np.int32] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_i8: CanPromote[np.int32] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_u8: CanPromote[np.int32] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_f2: CanPromote[np.int32] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_f4: CanPromote[np.int32] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_f8: CanPromote[np.int32] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_ld: CanPromote[np.int32] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_c8: CanPromote[np.int32] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_c16: CanPromote[np.int32] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_from_cld: CanPromote[np.int32] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+i4_to_b1: CanPromote[Any, np.int32] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_i1: CanPromote[Any, np.int32] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_u1: CanPromote[Any, np.int32] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_i2: CanPromote[Any, np.int32] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_u2: CanPromote[Any, np.int32] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_i4: CanPromote[Any, np.int32] = i4
+i4_to_u4: CanPromote[Any, np.int32] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_i8: CanPromote[Any, np.int32] = i8
+i4_to_u8: CanPromote[Any, np.int32] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_f2: CanPromote[Any, np.int32] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_f4: CanPromote[Any, np.int32] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_f8: CanPromote[Any, np.int32] = f8
+i4_to_ld: CanPromote[Any, np.int32] = ld
+i4_to_c8: CanPromote[Any, np.int32] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i4_to_c16: CanPromote[Any, np.int32] = c16
+i4_to_cld: CanPromote[Any, np.int32] = cld
+
+u4_from_b1: CanPromote[np.uint32] = b1
+u4_from_i1: CanPromote[np.uint32] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_u1: CanPromote[np.uint32] = u1
+u4_from_i2: CanPromote[np.uint32] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_u2: CanPromote[np.uint32] = u2
+u4_from_i4: CanPromote[np.uint32] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_u4: CanPromote[np.uint32] = u4
+u4_from_i8: CanPromote[np.uint32] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_u8: CanPromote[np.uint32] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_f2: CanPromote[np.uint32] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_f4: CanPromote[np.uint32] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_f8: CanPromote[np.uint32] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_ld: CanPromote[np.uint32] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_c8: CanPromote[np.uint32] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_c16: CanPromote[np.uint32] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_from_cld: CanPromote[np.uint32] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+u4_to_b1: CanPromote[Any, np.uint32] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_i1: CanPromote[Any, np.uint32] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_u1: CanPromote[Any, np.uint32] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_i2: CanPromote[Any, np.uint32] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_u2: CanPromote[Any, np.uint32] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_i4: CanPromote[Any, np.uint32] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_u4: CanPromote[Any, np.uint32] = u4
+u4_to_i8: CanPromote[Any, np.uint32] = i8
+u4_to_u8: CanPromote[Any, np.uint32] = u8
+u4_to_f2: CanPromote[Any, np.uint32] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_f4: CanPromote[Any, np.uint32] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_f8: CanPromote[Any, np.uint32] = f8
+u4_to_ld: CanPromote[Any, np.uint32] = ld
+u4_to_c8: CanPromote[Any, np.uint32] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u4_to_c16: CanPromote[Any, np.uint32] = c16
+u4_to_cld: CanPromote[Any, np.uint32] = cld
+
+i8_from_b1: CanPromote[np.int64] = b1
+i8_from_i1: CanPromote[np.int64] = i1
+i8_from_u1: CanPromote[np.int64] = u1
+i8_from_i2: CanPromote[np.int64] = i2
+i8_from_u2: CanPromote[np.int64] = u2
+i8_from_i4: CanPromote[np.int64] = i4
+i8_from_u4: CanPromote[np.int64] = u4
+i8_from_i8: CanPromote[np.int64] = i8
+i8_from_u8: CanPromote[np.int64] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_f2: CanPromote[np.int64] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_f4: CanPromote[np.int64] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_f8: CanPromote[np.int64] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_ld: CanPromote[np.int64] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_c8: CanPromote[np.int64] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_c16: CanPromote[np.int64] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_from_cld: CanPromote[np.int64] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+i8_to_b1: CanPromote[Any, np.int64] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_i1: CanPromote[Any, np.int64] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_u1: CanPromote[Any, np.int64] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_i2: CanPromote[Any, np.int64] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_u2: CanPromote[Any, np.int64] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_i4: CanPromote[Any, np.int64] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_u4: CanPromote[Any, np.int64] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_i8: CanPromote[Any, np.int64] = i8
+i8_to_u8: CanPromote[Any, np.int64] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_f2: CanPromote[Any, np.int64] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_f4: CanPromote[Any, np.int64] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_f8: CanPromote[Any, np.int64] = f8
+i8_to_ld: CanPromote[Any, np.int64] = ld
+i8_to_c8: CanPromote[Any, np.int64] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+i8_to_c16: CanPromote[Any, np.int64] = c16
+i8_to_cld: CanPromote[Any, np.int64] = cld
+
+u8_from_b1: CanPromote[np.uint64] = b1
+u8_from_i1: CanPromote[np.uint64] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_u1: CanPromote[np.uint64] = u1
+u8_from_i2: CanPromote[np.uint64] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_u2: CanPromote[np.uint64] = u2
+u8_from_i4: CanPromote[np.uint64] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_u4: CanPromote[np.uint64] = u4
+u8_from_i8: CanPromote[np.uint64] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_u8: CanPromote[np.uint64] = u8
+u8_from_f2: CanPromote[np.uint64] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_f4: CanPromote[np.uint64] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_f8: CanPromote[np.uint64] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_ld: CanPromote[np.uint64] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_c8: CanPromote[np.uint64] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_c16: CanPromote[np.uint64] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_from_cld: CanPromote[np.uint64] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+u8_to_b1: CanPromote[Any, np.uint64] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_i1: CanPromote[Any, np.uint64] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_u1: CanPromote[Any, np.uint64] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_i2: CanPromote[Any, np.uint64] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_u2: CanPromote[Any, np.uint64] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_i4: CanPromote[Any, np.uint64] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_u4: CanPromote[Any, np.uint64] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_i8: CanPromote[Any, np.uint64] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_u8: CanPromote[Any, np.uint64] = u8
+u8_to_f2: CanPromote[Any, np.uint64] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_f4: CanPromote[Any, np.uint64] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_f8: CanPromote[Any, np.uint64] = f8
+u8_to_ld: CanPromote[Any, np.uint64] = ld
+u8_to_c8: CanPromote[Any, np.uint64] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+u8_to_c16: CanPromote[Any, np.uint64] = c16
+u8_to_cld: CanPromote[Any, np.uint64] = cld
+
+f2_from_b1: CanPromote[np.float16] = b1
+f2_from_i1: CanPromote[np.float16] = i1
+f2_from_u1: CanPromote[np.float16] = u1
+f2_from_i2: CanPromote[np.float16] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_u2: CanPromote[np.float16] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_i4: CanPromote[np.float16] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_u4: CanPromote[np.float16] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_i8: CanPromote[np.float16] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_u8: CanPromote[np.float16] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_f2: CanPromote[np.float16] = f2
+f2_from_f4: CanPromote[np.float16] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_f8: CanPromote[np.float16] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_ld: CanPromote[np.float16] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_c8: CanPromote[np.float16] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_c16: CanPromote[np.float16] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_from_cld: CanPromote[np.float16] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+f2_to_b1: CanPromote[Any, np.float16] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_i1: CanPromote[Any, np.float16] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_u1: CanPromote[Any, np.float16] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_i2: CanPromote[Any, np.float16] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_u2: CanPromote[Any, np.float16] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_i4: CanPromote[Any, np.float16] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_u4: CanPromote[Any, np.float16] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_i8: CanPromote[Any, np.float16] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_u8: CanPromote[Any, np.float16] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f2_to_f2: CanPromote[Any, np.float16] = f2
+f2_to_f4: CanPromote[Any, np.float16] = f4
+f2_to_f8: CanPromote[Any, np.float16] = f8
+f2_to_ld: CanPromote[Any, np.float16] = ld
+f2_to_c8: CanPromote[Any, np.float16] = c8
+f2_to_c16: CanPromote[Any, np.float16] = c16
+f2_to_cld: CanPromote[Any, np.float16] = cld
+
+f4_from_b1: CanPromote[np.float32] = b1
+f4_from_i1: CanPromote[np.float32] = i1
+f4_from_u1: CanPromote[np.float32] = u1
+f4_from_i2: CanPromote[np.float32] = i2
+f4_from_u2: CanPromote[np.float32] = u2
+f4_from_i4: CanPromote[np.float32] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_u4: CanPromote[np.float32] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_i8: CanPromote[np.float32] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_u8: CanPromote[np.float32] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_f2: CanPromote[np.float32] = f2
+f4_from_f4: CanPromote[np.float32] = f4
+f4_from_f8: CanPromote[np.float32] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_ld: CanPromote[np.float32] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_c8: CanPromote[np.float32] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_c16: CanPromote[np.float32] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_from_cld: CanPromote[np.float32] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+f4_to_b1: CanPromote[Any, np.float32] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_i1: CanPromote[Any, np.float32] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_u1: CanPromote[Any, np.float32] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_i2: CanPromote[Any, np.float32] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_u2: CanPromote[Any, np.float32] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_i4: CanPromote[Any, np.float32] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_u4: CanPromote[Any, np.float32] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_i8: CanPromote[Any, np.float32] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_u8: CanPromote[Any, np.float32] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_f2: CanPromote[Any, np.float32] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f4_to_f4: CanPromote[Any, np.float32] = f4
+f4_to_f8: CanPromote[Any, np.float32] = f8
+f4_to_ld: CanPromote[Any, np.float32] = ld
+f4_to_c8: CanPromote[Any, np.float32] = c8
+f4_to_c16: CanPromote[Any, np.float32] = c16
+f4_to_cld: CanPromote[Any, np.float32] = cld
+
+f8_from_b1: CanPromote[np.float64] = b1
+f8_from_i1: CanPromote[np.float64] = i1
+f8_from_u1: CanPromote[np.float64] = u1
+f8_from_i2: CanPromote[np.float64] = i2
+f8_from_u2: CanPromote[np.float64] = u2
+f8_from_i4: CanPromote[np.float64] = i4
+f8_from_u4: CanPromote[np.float64] = u4
+f8_from_i8: CanPromote[np.float64] = i8
+f8_from_u8: CanPromote[np.float64] = u8
+f8_from_f2: CanPromote[np.float64] = f2
+f8_from_f4: CanPromote[np.float64] = f4
+f8_from_f8: CanPromote[np.float64] = f8
+f8_from_ld: CanPromote[np.float64] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_from_c8: CanPromote[np.float64] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_from_c16: CanPromote[np.float64] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_from_cld: CanPromote[np.float64] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+f8_to_b1: CanPromote[Any, np.float64] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_i1: CanPromote[Any, np.float64] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_u1: CanPromote[Any, np.float64] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_i2: CanPromote[Any, np.float64] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_u2: CanPromote[Any, np.float64] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_i4: CanPromote[Any, np.float64] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_u4: CanPromote[Any, np.float64] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_i8: CanPromote[Any, np.float64] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_u8: CanPromote[Any, np.float64] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_f2: CanPromote[Any, np.float64] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_f4: CanPromote[Any, np.float64] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_f8: CanPromote[Any, np.float64] = f8
+f8_to_ld: CanPromote[Any, np.float64] = ld
+f8_to_c8: CanPromote[Any, np.float64] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+f8_to_c16: CanPromote[Any, np.float64] = c16
+f8_to_cld: CanPromote[Any, np.float64] = cld
+
+ld_from_b1: CanPromote[np.longdouble] = b1
+ld_from_i1: CanPromote[np.longdouble] = i1
+ld_from_u1: CanPromote[np.longdouble] = u1
+ld_from_i2: CanPromote[np.longdouble] = i2
+ld_from_u2: CanPromote[np.longdouble] = u2
+ld_from_i4: CanPromote[np.longdouble] = i4
+ld_from_u4: CanPromote[np.longdouble] = u4
+ld_from_i8: CanPromote[np.longdouble] = i8
+ld_from_u8: CanPromote[np.longdouble] = u8
+ld_from_f2: CanPromote[np.longdouble] = f2
+ld_from_f4: CanPromote[np.longdouble] = f4
+ld_from_f8: CanPromote[np.longdouble] = f8
+ld_from_ld: CanPromote[np.longdouble] = ld
+ld_from_c8: CanPromote[np.longdouble] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_from_c16: CanPromote[np.longdouble] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_from_cld: CanPromote[np.longdouble] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+ld_to_b1: CanPromote[Any, np.longdouble] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_i1: CanPromote[Any, np.longdouble] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_u1: CanPromote[Any, np.longdouble] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_i2: CanPromote[Any, np.longdouble] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_u2: CanPromote[Any, np.longdouble] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_i4: CanPromote[Any, np.longdouble] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_u4: CanPromote[Any, np.longdouble] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_i8: CanPromote[Any, np.longdouble] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_u8: CanPromote[Any, np.longdouble] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_f2: CanPromote[Any, np.longdouble] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_f4: CanPromote[Any, np.longdouble] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_f8: CanPromote[Any, np.longdouble] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_ld: CanPromote[Any, np.longdouble] = ld
+ld_to_c8: CanPromote[Any, np.longdouble] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_c16: CanPromote[Any, np.longdouble] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+ld_to_cld: CanPromote[Any, np.longdouble] = cld
+
+c8_from_b1: CanPromote[np.complex64] = b1
+c8_from_i1: CanPromote[np.complex64] = i1
+c8_from_u1: CanPromote[np.complex64] = u1
+c8_from_i2: CanPromote[np.complex64] = i2
+c8_from_u2: CanPromote[np.complex64] = u2
+c8_from_i4: CanPromote[np.complex64] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_u4: CanPromote[np.complex64] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_i8: CanPromote[np.complex64] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_u8: CanPromote[np.complex64] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_f2: CanPromote[np.complex64] = f2
+c8_from_f4: CanPromote[np.complex64] = f4
+c8_from_f8: CanPromote[np.complex64] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_ld: CanPromote[np.complex64] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_c8: CanPromote[np.complex64] = c8
+c8_from_c16: CanPromote[np.complex64] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_from_cld: CanPromote[np.complex64] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+c8_to_b1: CanPromote[Any, np.complex64] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_i1: CanPromote[Any, np.complex64] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_u1: CanPromote[Any, np.complex64] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_i2: CanPromote[Any, np.complex64] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_u2: CanPromote[Any, np.complex64] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_i4: CanPromote[Any, np.complex64] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_u4: CanPromote[Any, np.complex64] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_i8: CanPromote[Any, np.complex64] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_u8: CanPromote[Any, np.complex64] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_f2: CanPromote[Any, np.complex64] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_f4: CanPromote[Any, np.complex64] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_f8: CanPromote[Any, np.complex64] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_ld: CanPromote[Any, np.complex64] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c8_to_c8: CanPromote[Any, np.complex64] = c8
+c8_to_c16: CanPromote[Any, np.complex64] = c16
+c8_to_cld: CanPromote[Any, np.complex64] = cld
+
+c16_from_b1: CanPromote[np.complex128] = b1
+c16_from_i1: CanPromote[np.complex128] = i1
+c16_from_u1: CanPromote[np.complex128] = u1
+c16_from_i2: CanPromote[np.complex128] = i2
+c16_from_u2: CanPromote[np.complex128] = u2
+c16_from_i4: CanPromote[np.complex128] = i4
+c16_from_u4: CanPromote[np.complex128] = u4
+c16_from_i8: CanPromote[np.complex128] = i8
+c16_from_u8: CanPromote[np.complex128] = u8
+c16_from_f2: CanPromote[np.complex128] = f2
+c16_from_f4: CanPromote[np.complex128] = f4
+c16_from_f8: CanPromote[np.complex128] = f8
+c16_from_ld: CanPromote[np.complex128] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_from_c8: CanPromote[np.complex128] = c8
+c16_from_c16: CanPromote[np.complex128] = c16
+c16_from_cld: CanPromote[np.complex128] = cld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+
+c16_to_b1: CanPromote[Any, np.complex128] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_i1: CanPromote[Any, np.complex128] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_u1: CanPromote[Any, np.complex128] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_i2: CanPromote[Any, np.complex128] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_u2: CanPromote[Any, np.complex128] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_i4: CanPromote[Any, np.complex128] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_u4: CanPromote[Any, np.complex128] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_i8: CanPromote[Any, np.complex128] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_u8: CanPromote[Any, np.complex128] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_f2: CanPromote[Any, np.complex128] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_f4: CanPromote[Any, np.complex128] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_f8: CanPromote[Any, np.complex128] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_ld: CanPromote[Any, np.complex128] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_c8: CanPromote[Any, np.complex128] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+c16_to_c16: CanPromote[Any, np.complex128] = c16
+c16_to_cld: CanPromote[Any, np.complex128] = cld
+
+cld_from_b1: CanPromote[np.clongdouble] = b1
+cld_from_i1: CanPromote[np.clongdouble] = i1
+cld_from_u1: CanPromote[np.clongdouble] = u1
+cld_from_i2: CanPromote[np.clongdouble] = i2
+cld_from_u2: CanPromote[np.clongdouble] = u2
+cld_from_i4: CanPromote[np.clongdouble] = i4
+cld_from_u4: CanPromote[np.clongdouble] = u4
+cld_from_i8: CanPromote[np.clongdouble] = i8
+cld_from_u8: CanPromote[np.clongdouble] = u8
+cld_from_f2: CanPromote[np.clongdouble] = f2
+cld_from_f4: CanPromote[np.clongdouble] = f4
+cld_from_f8: CanPromote[np.clongdouble] = f8
+cld_from_ld: CanPromote[np.clongdouble] = ld
+cld_from_c8: CanPromote[np.clongdouble] = c8
+cld_from_c16: CanPromote[np.clongdouble] = c16
+cld_from_cld: CanPromote[np.clongdouble] = cld
+
+cld_to_b1: CanPromote[Any, np.clongdouble] = b1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_i1: CanPromote[Any, np.clongdouble] = i1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_u1: CanPromote[Any, np.clongdouble] = u1  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_i2: CanPromote[Any, np.clongdouble] = i2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_u2: CanPromote[Any, np.clongdouble] = u2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_i4: CanPromote[Any, np.clongdouble] = i4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_u4: CanPromote[Any, np.clongdouble] = u4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_i8: CanPromote[Any, np.clongdouble] = i8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_u8: CanPromote[Any, np.clongdouble] = u8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_f2: CanPromote[Any, np.clongdouble] = f2  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_f4: CanPromote[Any, np.clongdouble] = f4  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_f8: CanPromote[Any, np.clongdouble] = f8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_ld: CanPromote[Any, np.clongdouble] = ld  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_c8: CanPromote[Any, np.clongdouble] = c8  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_c16: CanPromote[Any, np.clongdouble] = c16  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
+cld_to_cld: CanPromote[Any, np.clongdouble] = cld

--- a/src/_numtype/__init__.pyi
+++ b/src/_numtype/__init__.pyi
@@ -61,6 +61,7 @@ from ._scalar import (
     number64 as number64,
 )
 from ._scalar_co import (
+    CanPromote as CanPromote,
     co_complex as co_complex,
     co_complex64 as co_complex64,
     co_complex128 as co_complex128,

--- a/src/_numtype/_scalar_co.pyi
+++ b/src/_numtype/_scalar_co.pyi
@@ -1,10 +1,12 @@
-from typing import TypeAlias
+from typing import Any, Protocol, TypeAlias, type_check_only
+from typing_extensions import TypeVar
 
 import numpy as np
 
 from ._scalar import inexact32, integer8, integer16, integer32, number16, number32, number64
 
 __all__ = [
+    "CanPromote",
     "co_complex",
     "co_complex64",
     "co_complex128",
@@ -31,6 +33,27 @@ __all__ = [
     "co_uint64",
     "co_ulong",
 ]
+
+_T_co = TypeVar("_T_co", covariant=True)
+_ToT_contra = TypeVar("_ToT_contra", bound=np.generic, contravariant=True)
+_FromT_contra = TypeVar("_FromT_contra", bound=np.generic, contravariant=True, default=Any)
+_SelfT_co = TypeVar("_SelfT_co", bound=np.generic, covariant=True, default=Any)
+
+@type_check_only
+class _HasType(Protocol[_T_co]):
+    @property
+    def type(self, /) -> type[_T_co]: ...
+
+@type_check_only
+class _CanPromote(Protocol[_ToT_contra, _FromT_contra, _SelfT_co]):
+    def __promote__(self, to: _ToT_contra, from_: _FromT_contra, /) -> _SelfT_co: ...
+
+@type_check_only
+class CanPromote(Protocol[_ToT_contra, _FromT_contra, _SelfT_co]):
+    @property
+    def shape(self, /) -> tuple[()]: ...
+    @property
+    def dtype(self, /) -> _HasType[_CanPromote[_ToT_contra, _FromT_contra, _SelfT_co]]: ...
 
 ###
 # Coercible (overlapping) scalar- and array-likes

--- a/src/numpy-stubs/__init__.pyi
+++ b/src/numpy-stubs/__init__.pyi
@@ -5090,6 +5090,10 @@ class complexfloating(inexact[_BitT1, complex], Generic[_BitT1, _BitT2]):
 
 # NOTE: Naming it `bool_` results in less unreadable type-checker output
 class bool_(generic[_BoolItemT_co], Generic[_BoolItemT_co]):
+    @type_check_only
+    def __promote__(self, to: bool_ | number, from_: bool_, /) -> bool_: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[1]: ...
@@ -5632,6 +5636,10 @@ class _IntROpMixin(Generic[_T_co]):
     def __ror__(self, x: _JustSignedInteger | _JustUnsignedInteger | _nt.Just[integer], /) -> _T_co: ...
 
 class int8(_IntROpMixin[signedinteger], signedinteger[_n._8]):  # type: ignore[misc]
+    @type_check_only
+    def __promote__(self, to: signedinteger | inexact, from_: int8 | bool_, /) -> int8: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[1]: ...
@@ -5762,6 +5770,15 @@ class int8(_IntROpMixin[signedinteger], signedinteger[_n._8]):  # type: ignore[m
     def __or__(self, x: _nt.Just[_SignedIntegerT], /) -> _SignedIntegerT: ...
 
 class uint8(unsignedinteger[_n._8]):
+    @type_check_only
+    def __promote__(
+        self,
+        to: uint8 | int16 | int32 | int64 | unsignedinteger | inexact,
+        from_: uint8 | bool_,
+        /,
+    ) -> uint8: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[1]: ...
@@ -6202,6 +6219,15 @@ class uint8(unsignedinteger[_n._8]):
     def __ror__(self, x: _nt.Just[integer], /) -> integer: ...
 
 class int16(_IntROpMixin[signedinteger], signedinteger[_n._16]):  # type: ignore[misc]
+    @type_check_only
+    def __promote__(
+        self,
+        to: int16 | int32 | int64 | float32 | float64 | longdouble | complexfloating,
+        from_: int16 | uint8 | int8 | bool_,
+        /,
+    ) -> int16: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[2]: ...
@@ -6370,6 +6396,15 @@ class int16(_IntROpMixin[signedinteger], signedinteger[_n._16]):  # type: ignore
     def __or__(self, x: _nt.CanArray0D[int32], /) -> int32: ...
 
 class uint16(unsignedinteger[_n._16]):
+    @type_check_only
+    def __promote__(
+        self,
+        to: uint16 | int32 | uint32 | int64 | uint64 | float32 | float64 | longdouble | complexfloating,
+        from_: uint16 | uint8 | bool_,
+        /,
+    ) -> uint16: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[2]: ...
@@ -6762,6 +6797,15 @@ class uint16(unsignedinteger[_n._16]):
     def __ror__(self, x: _nt.Just[integer], /) -> integer: ...
 
 class int32(_IntROpMixin[signedinteger], signedinteger[_n._32]):  # type: ignore[misc]
+    @type_check_only
+    def __promote__(
+        self,
+        to: int32 | int64 | float64 | complex128 | longdouble | clongdouble,
+        from_: int32 | uint16 | int16 | uint8 | int8 | bool_,
+        /,
+    ) -> int32: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[4]: ...
@@ -6906,6 +6950,15 @@ class int32(_IntROpMixin[signedinteger], signedinteger[_n._32]):  # type: ignore
     def __or__(self, x: _nt.CanArray0D[int64], /) -> int64: ...
 
 class uint32(unsignedinteger[_n._32]):
+    @type_check_only
+    def __promote__(
+        self,
+        to: uint32 | int64 | uint64 | float64 | complex128 | longdouble | clongdouble,
+        from_: uint32 | uint16 | uint8 | bool_,
+        /,
+    ) -> uint32: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[4]: ...
@@ -7202,6 +7255,15 @@ class uint32(unsignedinteger[_n._32]):
     def __ror__(self, x: _nt.Just[integer], /) -> integer: ...
 
 class int64(_IntROpMixin[int64], signedinteger[_n._64]):  # type: ignore[misc]
+    @type_check_only
+    def __promote__(
+        self,
+        to: int64 | float64 | complex128 | longdouble | clongdouble,
+        from_: signedinteger | uint32 | uint16 | uint8 | bool_,
+        /,
+    ) -> int64: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[8]: ...
@@ -7309,6 +7371,15 @@ class int64(_IntROpMixin[int64], signedinteger[_n._64]):  # type: ignore[misc]
     def __or__(self, x: _JustInteger, /) -> int64: ...
 
 class uint64(unsignedinteger[_n._64]):
+    @type_check_only
+    def __promote__(
+        self,
+        to: uint64 | float64 | complex128 | longdouble | clongdouble,
+        from_: unsignedinteger | bool_,
+        /,
+    ) -> uint64: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[8]: ...
@@ -7537,6 +7608,10 @@ longlong = int64
 ulonglong = uint64
 
 class float16(floating[_n._16]):
+    @type_check_only
+    def __promote__(self, to: inexact, from_: float16 | int8 | uint8 | bool_, /) -> float16: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[2]: ...
@@ -7791,6 +7866,15 @@ class float16(floating[_n._16]):
     def __rdivmod__(self, x: _JustInteger | _JustFloating | _nt.Just[inexact], /) -> _2Tuple[floating]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
 class float32(floating[_n._32]):
+    @type_check_only
+    def __promote__(
+        self,
+        to: float32 | float64 | longdouble | complexfloating,
+        from_: float32 | float16 | int16 | uint16 | int8 | uint8 | bool_,
+        /,
+    ) -> float32: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[4]: ...
@@ -7987,6 +8071,15 @@ class float32(floating[_n._32]):
     def __rdivmod__(self, x: _JustInteger | _JustFloating | _nt.Just[inexact], /) -> _2Tuple[floating]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
 class float64(floating[_n._64], float):  # type: ignore[misc]
+    @type_check_only
+    def __promote__(
+        self,
+        to: float64 | longdouble | complex128 | clongdouble,
+        from_: float64 | float32 | float16 | integer | bool_,
+        /,
+    ) -> float64: ...
+
+    #
     def __new__(cls, x: _ConvertibleToFloat | None = 0, /) -> Self: ...
     @classmethod
     def __getformat__(cls, typestr: L["double", "float"], /) -> str: ...
@@ -8180,6 +8273,10 @@ single = float32
 double = float64
 
 class longdouble(floating[_n._64L]):
+    @type_check_only
+    def __promote__(self, to: longdouble | clongdouble, from_: floating | integer | bool_, /) -> longdouble: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[12, 16]: ...
@@ -8303,6 +8400,15 @@ float96 = longdouble
 float128 = longdouble
 
 class complex64(complexfloating[_n._32]):
+    @type_check_only
+    def __promote__(
+        self,
+        to: complexfloating,
+        from_: complex64 | float32 | float16 | int16 | uint16 | int8 | uint8 | bool_,
+        /,
+    ) -> complex64: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[8]: ...
@@ -8426,6 +8532,15 @@ class complex64(complexfloating[_n._32]):
     def __complex__(self, /) -> complex: ...
 
 class complex128(complexfloating[_n._64], complex):
+    @type_check_only
+    def __promote__(
+        self,
+        to: complex128 | clongdouble,
+        from_: complex128 | complex64 | float64 | float32 | float16 | integer | bool_,
+        /,
+    ) -> complex128: ...
+
+    #
     @overload
     def __new__(cls, real: _ConvertibleToComplex | None = 0, /) -> Self: ...
     @overload
@@ -8542,6 +8657,10 @@ csingle = complex64
 cdouble = complex128
 
 class clongdouble(complexfloating[_n._64L]):
+    @type_check_only
+    def __promote__(self, to: clongdouble, from_: number | bool_, /) -> clongdouble: ...
+
+    #
     @property
     @override
     def itemsize(self) -> L[24, 32]: ...


### PR DESCRIPTION
Closes #137

---

This embeds the [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html) scalar promotion rules as static typing information within the scalar types. The new `_numtype.CanPromote` generic protocol is the interface. The plan is to make it part of the public `numtype` interface, once it is considered stable enough.
See  `src/_numtype/@test/test_can_promote.pyi` for how it can be used.

![NEP 50 scalar promotion rules](https://numpy.org/neps/_images/nep-0050-promotion-no-fonts.svg)