### PR TITLE
🤖 `ndarray` binop testgen with abstract scalar types

### DIFF
--- a/src/numpy-stubs/@test/generated/ndarray_ops_add.pyi
+++ b/src/numpy-stubs/@test/generated/ndarray_ops_add.pyi
@@ -1,4 +1,4 @@
-# @generated 2025-04-13T21:19:18Z with tool/testgen.py
+# @generated 2025-04-13T23:42:04Z with tool/testgen.py
 from typing_extensions import assert_type
 
 import numpy as np
@@ -28,6 +28,10 @@ O_nd: npt.NDArray[np.object_]
 S_nd: npt.NDArray[np.bytes_]
 U_nd: npt.NDArray[np.str_]
 T_nd: np.ndarray[tuple[int, ...], np.dtypes.StringDType]
+i_nd: npt.NDArray[np.signedinteger]
+u_nd: npt.NDArray[np.unsignedinteger]
+f_nd: npt.NDArray[np.floating]
+c_nd: npt.NDArray[np.complexfloating]
 
 b_py: bool
 i_py: int
@@ -60,6 +64,10 @@ assert_type(b1_nd + O_nd, npt.NDArray[np.object_])
 b1_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 b1_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 b1_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(b1_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(b1_nd + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(b1_nd + f_nd, npt.NDArray[np.floating])
+assert_type(b1_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(b1_nd + b_py, npt.NDArray[np.bool])
 assert_type(b1_nd + i_py, npt.NDArray[np.int64])
@@ -96,6 +104,10 @@ assert_type(i1_nd + O_nd, npt.NDArray[np.object_])
 i1_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i1_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i1_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(i1_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(i1_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i1_nd + f_nd, npt.NDArray[np.floating])
+assert_type(i1_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(i1_nd + b_py, npt.NDArray[np.int8])
 assert_type(i1_nd + i_py, npt.NDArray[np.int8])
@@ -132,6 +144,10 @@ assert_type(i2_nd + O_nd, npt.NDArray[np.object_])
 i2_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i2_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i2_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(i2_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(i2_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i2_nd + f_nd, npt.NDArray[np.floating])
+assert_type(i2_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(i2_nd + b_py, npt.NDArray[np.int16])
 assert_type(i2_nd + i_py, npt.NDArray[np.int16])
@@ -168,6 +184,10 @@ assert_type(i4_nd + O_nd, npt.NDArray[np.object_])
 i4_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i4_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i4_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(i4_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(i4_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i4_nd + f_nd, npt.NDArray[np.floating])
+assert_type(i4_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(i4_nd + b_py, npt.NDArray[np.int32])
 assert_type(i4_nd + i_py, npt.NDArray[np.int32])
@@ -204,6 +224,10 @@ assert_type(i8_nd + O_nd, npt.NDArray[np.object_])
 i8_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i8_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 i8_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(i8_nd + i_nd, npt.NDArray[np.int64])
+assert_type(i8_nd + u_nd, npt.NDArray[np.int64 | np.float64])
+assert_type(i8_nd + f_nd, npt.NDArray[np.floating])
+assert_type(i8_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(i8_nd + b_py, npt.NDArray[np.int64])
 assert_type(i8_nd + i_py, npt.NDArray[np.int64])
@@ -240,6 +264,10 @@ assert_type(u1_nd + O_nd, npt.NDArray[np.object_])
 u1_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u1_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u1_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(u1_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(u1_nd + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u1_nd + f_nd, npt.NDArray[np.floating])
+assert_type(u1_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(u1_nd + b_py, npt.NDArray[np.uint8])
 assert_type(u1_nd + i_py, npt.NDArray[np.uint8])
@@ -276,6 +304,10 @@ assert_type(u2_nd + O_nd, npt.NDArray[np.object_])
 u2_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u2_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u2_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(u2_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(u2_nd + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u2_nd + f_nd, npt.NDArray[np.floating])
+assert_type(u2_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(u2_nd + b_py, npt.NDArray[np.uint16])
 assert_type(u2_nd + i_py, npt.NDArray[np.uint16])
@@ -312,6 +344,10 @@ assert_type(u4_nd + O_nd, npt.NDArray[np.object_])
 u4_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u4_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u4_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(u4_nd + i_nd, npt.NDArray[np.int64])
+assert_type(u4_nd + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u4_nd + f_nd, npt.NDArray[np.floating])
+assert_type(u4_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(u4_nd + b_py, npt.NDArray[np.uint32])
 assert_type(u4_nd + i_py, npt.NDArray[np.uint32])
@@ -348,6 +384,10 @@ assert_type(u8_nd + O_nd, npt.NDArray[np.object_])
 u8_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u8_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 u8_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(u8_nd + i_nd, npt.NDArray[np.float64])
+assert_type(u8_nd + u_nd, npt.NDArray[np.uint64])
+assert_type(u8_nd + f_nd, npt.NDArray[np.floating])
+assert_type(u8_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(u8_nd + b_py, npt.NDArray[np.uint64])
 assert_type(u8_nd + i_py, npt.NDArray[np.uint64])
@@ -384,6 +424,10 @@ assert_type(f2_nd + O_nd, npt.NDArray[np.object_])
 f2_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f2_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f2_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(f2_nd + i_nd, npt.NDArray[np.floating])
+assert_type(f2_nd + u_nd, npt.NDArray[np.floating])
+assert_type(f2_nd + f_nd, npt.NDArray[np.floating])
+assert_type(f2_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(f2_nd + b_py, npt.NDArray[np.float16])
 assert_type(f2_nd + i_py, npt.NDArray[np.float16])
@@ -420,6 +464,10 @@ assert_type(f4_nd + O_nd, npt.NDArray[np.object_])
 f4_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f4_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f4_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(f4_nd + i_nd, npt.NDArray[np.floating])
+assert_type(f4_nd + u_nd, npt.NDArray[np.floating])
+assert_type(f4_nd + f_nd, npt.NDArray[np.floating])
+assert_type(f4_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(f4_nd + b_py, npt.NDArray[np.float32])
 assert_type(f4_nd + i_py, npt.NDArray[np.float32])
@@ -456,6 +504,10 @@ assert_type(f8_nd + O_nd, npt.NDArray[np.object_])
 f8_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f8_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f8_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(f8_nd + i_nd, npt.NDArray[np.float64])
+assert_type(f8_nd + u_nd, npt.NDArray[np.float64])
+assert_type(f8_nd + f_nd, npt.NDArray[np.floating])
+assert_type(f8_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(f8_nd + b_py, npt.NDArray[np.float64])
 assert_type(f8_nd + i_py, npt.NDArray[np.float64])
@@ -492,6 +544,10 @@ assert_type(fld_nd + O_nd, npt.NDArray[np.object_])
 fld_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 fld_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 fld_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(fld_nd + i_nd, npt.NDArray[np.longdouble])
+assert_type(fld_nd + u_nd, npt.NDArray[np.longdouble])
+assert_type(fld_nd + f_nd, npt.NDArray[np.longdouble])
+assert_type(fld_nd + c_nd, npt.NDArray[np.clongdouble])
 
 assert_type(fld_nd + b_py, npt.NDArray[np.longdouble])
 assert_type(fld_nd + i_py, npt.NDArray[np.longdouble])
@@ -528,6 +584,10 @@ assert_type(c8_nd + O_nd, npt.NDArray[np.object_])
 c8_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 c8_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 c8_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(c8_nd + i_nd, npt.NDArray[np.complexfloating])
+assert_type(c8_nd + u_nd, npt.NDArray[np.complexfloating])
+assert_type(c8_nd + f_nd, npt.NDArray[np.complexfloating])
+assert_type(c8_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(c8_nd + b_py, npt.NDArray[np.complex64])
 assert_type(c8_nd + i_py, npt.NDArray[np.complex64])
@@ -564,6 +624,10 @@ assert_type(c16_nd + O_nd, npt.NDArray[np.object_])
 c16_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 c16_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 c16_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(c16_nd + i_nd, npt.NDArray[np.complex128])
+assert_type(c16_nd + u_nd, npt.NDArray[np.complex128])
+assert_type(c16_nd + f_nd, npt.NDArray[np.complexfloating])
+assert_type(c16_nd + c_nd, npt.NDArray[np.complexfloating])
 
 assert_type(c16_nd + b_py, npt.NDArray[np.complex128])
 assert_type(c16_nd + i_py, npt.NDArray[np.complex128])
@@ -600,6 +664,10 @@ assert_type(cld_nd + O_nd, npt.NDArray[np.object_])
 cld_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 cld_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 cld_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(cld_nd + i_nd, npt.NDArray[np.clongdouble])
+assert_type(cld_nd + u_nd, npt.NDArray[np.clongdouble])
+assert_type(cld_nd + f_nd, npt.NDArray[np.clongdouble])
+assert_type(cld_nd + c_nd, npt.NDArray[np.clongdouble])
 
 assert_type(cld_nd + b_py, npt.NDArray[np.clongdouble])
 assert_type(cld_nd + i_py, npt.NDArray[np.clongdouble])
@@ -635,6 +703,10 @@ assert_type(M8_nd + m8_nd, npt.NDArray[np.datetime64])
 M8_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 M8_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 M8_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(M8_nd + i_nd, npt.NDArray[np.datetime64])
+assert_type(M8_nd + u_nd, npt.NDArray[np.datetime64])
+M8_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+M8_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 assert_type(M8_nd + b_py, npt.NDArray[np.datetime64])
 assert_type(M8_nd + i_py, npt.NDArray[np.datetime64])
@@ -670,6 +742,10 @@ assert_type(m8_nd + m8_nd, npt.NDArray[np.timedelta64])
 m8_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 m8_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 m8_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(m8_nd + i_nd, npt.NDArray[np.timedelta64])
+assert_type(m8_nd + u_nd, npt.NDArray[np.timedelta64])
+m8_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+m8_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 assert_type(m8_nd + b_py, npt.NDArray[np.timedelta64])
 assert_type(m8_nd + i_py, npt.NDArray[np.timedelta64])
@@ -703,6 +779,10 @@ assert_type(O_nd + cld_nd, npt.NDArray[np.object_])
 assert_type(O_nd + O_nd, npt.NDArray[np.object_])
 assert_type(O_nd + S_nd, npt.NDArray[np.object_])
 assert_type(O_nd + U_nd, npt.NDArray[np.object_])
+assert_type(O_nd + i_nd, npt.NDArray[np.object_])
+assert_type(O_nd + u_nd, npt.NDArray[np.object_])
+assert_type(O_nd + f_nd, npt.NDArray[np.object_])
+assert_type(O_nd + c_nd, npt.NDArray[np.object_])
 
 assert_type(O_nd + b_py, npt.NDArray[np.object_])
 assert_type(O_nd + i_py, npt.NDArray[np.object_])
@@ -739,6 +819,10 @@ assert_type(S_nd + O_nd, npt.NDArray[np.object_])
 assert_type(S_nd + S_nd, npt.NDArray[np.bytes_])
 S_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 S_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 S_nd + b_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 S_nd + i_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
@@ -775,6 +859,10 @@ assert_type(U_nd + O_nd, npt.NDArray[np.object_])
 U_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 assert_type(U_nd + U_nd, npt.NDArray[np.str_])
 assert_type(U_nd + T_nd, np.ndarray[tuple[int, ...], np.dtypes.StringDType])
+U_nd + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+U_nd + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+U_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+U_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 U_nd + b_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 U_nd + i_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
@@ -810,6 +898,10 @@ T_nd + m8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 T_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 assert_type(T_nd + U_nd, np.ndarray[tuple[int, ...], np.dtypes.StringDType])
 assert_type(T_nd + T_nd, np.ndarray[tuple[int, ...], np.dtypes.StringDType])
+T_nd + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+T_nd + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+T_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+T_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 T_nd + b_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 T_nd + i_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
@@ -823,3 +915,163 @@ i_py + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 f_py + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 c_py + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 assert_type(U_py + T_nd, np.ndarray[tuple[int, ...], np.dtypes.StringDType])
+
+assert_type(i_nd + b1_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + i1_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + i2_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + i4_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + i8_nd, npt.NDArray[np.int64])
+assert_type(i_nd + u1_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + u2_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + u4_nd, npt.NDArray[np.int64])
+assert_type(i_nd + u8_nd, npt.NDArray[np.float64])
+assert_type(i_nd + f2_nd, npt.NDArray[np.floating])
+assert_type(i_nd + f4_nd, npt.NDArray[np.floating])
+assert_type(i_nd + f8_nd, npt.NDArray[np.float64])
+assert_type(i_nd + fld_nd, npt.NDArray[np.longdouble])
+assert_type(i_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(i_nd + c16_nd, npt.NDArray[np.complex128])
+assert_type(i_nd + cld_nd, npt.NDArray[np.clongdouble])
+assert_type(i_nd + M8_nd, npt.NDArray[np.datetime64])
+assert_type(i_nd + m8_nd, npt.NDArray[np.timedelta64])
+assert_type(i_nd + O_nd, npt.NDArray[np.object_])
+i_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+i_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+i_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(i_nd + i_nd, npt.NDArray[np.signedinteger])
+assert_type(i_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i_nd + f_nd, npt.NDArray[np.floating])
+assert_type(i_nd + c_nd, npt.NDArray[np.complexfloating])
+
+assert_type(i_nd + b_py, npt.NDArray[np.signedinteger])
+assert_type(i_nd + i_py, npt.NDArray[np.signedinteger])
+assert_type(i_nd + f_py, npt.NDArray[np.float64])
+assert_type(i_nd + c_py, npt.NDArray[np.complex128])
+i_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+i_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + i_nd, npt.NDArray[np.signedinteger])
+assert_type(i_py + i_nd, npt.NDArray[np.signedinteger])
+assert_type(f_py + i_nd, npt.NDArray[np.float64])
+assert_type(c_py + i_nd, npt.NDArray[np.complex128])
+U_py + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(u_nd + b1_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + i1_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(u_nd + i2_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(u_nd + i4_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(u_nd + i8_nd, npt.NDArray[np.int64 | np.float64])
+assert_type(u_nd + u1_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + u2_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + u4_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + u8_nd, npt.NDArray[np.uint64])
+assert_type(u_nd + f2_nd, npt.NDArray[np.floating])
+assert_type(u_nd + f4_nd, npt.NDArray[np.floating])
+assert_type(u_nd + f8_nd, npt.NDArray[np.float64])
+assert_type(u_nd + fld_nd, npt.NDArray[np.longdouble])
+assert_type(u_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(u_nd + c16_nd, npt.NDArray[np.complex128])
+assert_type(u_nd + cld_nd, npt.NDArray[np.clongdouble])
+assert_type(u_nd + M8_nd, npt.NDArray[np.datetime64])
+assert_type(u_nd + m8_nd, npt.NDArray[np.timedelta64])
+assert_type(u_nd + O_nd, npt.NDArray[np.object_])
+u_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+u_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+u_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(u_nd + i_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(u_nd + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + f_nd, npt.NDArray[np.floating])
+assert_type(u_nd + c_nd, npt.NDArray[np.complexfloating])
+
+assert_type(u_nd + b_py, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + i_py, npt.NDArray[np.unsignedinteger])
+assert_type(u_nd + f_py, npt.NDArray[np.float64])
+assert_type(u_nd + c_py, npt.NDArray[np.complex128])
+u_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+u_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(i_py + u_nd, npt.NDArray[np.unsignedinteger])
+assert_type(f_py + u_nd, npt.NDArray[np.float64])
+assert_type(c_py + u_nd, npt.NDArray[np.complex128])
+U_py + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(f_nd + b1_nd, npt.NDArray[np.floating])
+assert_type(f_nd + i1_nd, npt.NDArray[np.floating])
+assert_type(f_nd + i2_nd, npt.NDArray[np.floating])
+assert_type(f_nd + i4_nd, npt.NDArray[np.floating])
+assert_type(f_nd + i8_nd, npt.NDArray[np.floating])
+assert_type(f_nd + u1_nd, npt.NDArray[np.floating])
+assert_type(f_nd + u2_nd, npt.NDArray[np.floating])
+assert_type(f_nd + u4_nd, npt.NDArray[np.floating])
+assert_type(f_nd + u8_nd, npt.NDArray[np.floating])
+assert_type(f_nd + f2_nd, npt.NDArray[np.floating])
+assert_type(f_nd + f4_nd, npt.NDArray[np.floating])
+assert_type(f_nd + f8_nd, npt.NDArray[np.floating])
+assert_type(f_nd + fld_nd, npt.NDArray[np.longdouble])
+assert_type(f_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(f_nd + c16_nd, npt.NDArray[np.complexfloating])
+assert_type(f_nd + cld_nd, npt.NDArray[np.clongdouble])
+f_nd + M8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+f_nd + m8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(f_nd + O_nd, npt.NDArray[np.object_])
+f_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+f_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+f_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(f_nd + i_nd, npt.NDArray[np.floating])
+assert_type(f_nd + u_nd, npt.NDArray[np.floating])
+assert_type(f_nd + f_nd, npt.NDArray[np.floating])
+assert_type(f_nd + c_nd, npt.NDArray[np.complexfloating])
+
+assert_type(f_nd + b_py, npt.NDArray[np.floating])
+assert_type(f_nd + i_py, npt.NDArray[np.floating])
+assert_type(f_nd + f_py, npt.NDArray[np.floating])
+assert_type(f_nd + c_py, npt.NDArray[np.complexfloating])
+f_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+f_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + f_nd, npt.NDArray[np.floating])
+assert_type(i_py + f_nd, npt.NDArray[np.floating])
+assert_type(f_py + f_nd, npt.NDArray[np.floating])
+assert_type(c_py + f_nd, npt.NDArray[np.complexfloating])
+U_py + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(c_nd + b1_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + i1_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + i2_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + i4_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + i8_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + u1_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + u2_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + u4_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + u8_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + f2_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + f4_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + f8_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + fld_nd, npt.NDArray[np.clongdouble])
+assert_type(c_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + c16_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + cld_nd, npt.NDArray[np.clongdouble])
+c_nd + M8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+c_nd + m8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(c_nd + O_nd, npt.NDArray[np.object_])
+c_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+c_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+c_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(c_nd + i_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + u_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + f_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + c_nd, npt.NDArray[np.complexfloating])
+
+assert_type(c_nd + b_py, npt.NDArray[np.complexfloating])
+assert_type(c_nd + i_py, npt.NDArray[np.complexfloating])
+assert_type(c_nd + f_py, npt.NDArray[np.complexfloating])
+assert_type(c_nd + c_py, npt.NDArray[np.complexfloating])
+c_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+c_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + c_nd, npt.NDArray[np.complexfloating])
+assert_type(i_py + c_nd, npt.NDArray[np.complexfloating])
+assert_type(f_py + c_nd, npt.NDArray[np.complexfloating])
+assert_type(c_py + c_nd, npt.NDArray[np.complexfloating])
+U_py + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]

--- a/src/numpy-stubs/@test/generated/ndarray_ops_add.pyi
+++ b/src/numpy-stubs/@test/generated/ndarray_ops_add.pyi
@@ -1,4 +1,4 @@
-# @generated 2025-04-13T23:42:04Z with tool/testgen.py
+# @generated 2025-04-13T23:57:03Z with tool/testgen.py
 from typing_extensions import assert_type
 
 import numpy as np
@@ -32,6 +32,9 @@ i_nd: npt.NDArray[np.signedinteger]
 u_nd: npt.NDArray[np.unsignedinteger]
 f_nd: npt.NDArray[np.floating]
 c_nd: npt.NDArray[np.complexfloating]
+iu_nd: npt.NDArray[np.integer]
+fc_nd: npt.NDArray[np.inexact]
+iufc_nd: npt.NDArray[np.number]
 
 b_py: bool
 i_py: int
@@ -68,6 +71,9 @@ assert_type(b1_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(b1_nd + u_nd, npt.NDArray[np.unsignedinteger])
 assert_type(b1_nd + f_nd, npt.NDArray[np.floating])
 assert_type(b1_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(b1_nd + iu_nd, npt.NDArray[np.integer])
+assert_type(b1_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(b1_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(b1_nd + b_py, npt.NDArray[np.bool])
 assert_type(b1_nd + i_py, npt.NDArray[np.int64])
@@ -108,6 +114,9 @@ assert_type(i1_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(i1_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
 assert_type(i1_nd + f_nd, npt.NDArray[np.floating])
 assert_type(i1_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(i1_nd + iu_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i1_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(i1_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(i1_nd + b_py, npt.NDArray[np.int8])
 assert_type(i1_nd + i_py, npt.NDArray[np.int8])
@@ -148,6 +157,9 @@ assert_type(i2_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(i2_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
 assert_type(i2_nd + f_nd, npt.NDArray[np.floating])
 assert_type(i2_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(i2_nd + iu_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i2_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(i2_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(i2_nd + b_py, npt.NDArray[np.int16])
 assert_type(i2_nd + i_py, npt.NDArray[np.int16])
@@ -188,6 +200,9 @@ assert_type(i4_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(i4_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
 assert_type(i4_nd + f_nd, npt.NDArray[np.floating])
 assert_type(i4_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(i4_nd + iu_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i4_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(i4_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(i4_nd + b_py, npt.NDArray[np.int32])
 assert_type(i4_nd + i_py, npt.NDArray[np.int32])
@@ -228,6 +243,9 @@ assert_type(i8_nd + i_nd, npt.NDArray[np.int64])
 assert_type(i8_nd + u_nd, npt.NDArray[np.int64 | np.float64])
 assert_type(i8_nd + f_nd, npt.NDArray[np.floating])
 assert_type(i8_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(i8_nd + iu_nd, npt.NDArray[np.int64 | np.float64])
+assert_type(i8_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(i8_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(i8_nd + b_py, npt.NDArray[np.int64])
 assert_type(i8_nd + i_py, npt.NDArray[np.int64])
@@ -268,6 +286,9 @@ assert_type(u1_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(u1_nd + u_nd, npt.NDArray[np.unsignedinteger])
 assert_type(u1_nd + f_nd, npt.NDArray[np.floating])
 assert_type(u1_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(u1_nd + iu_nd, npt.NDArray[np.integer])
+assert_type(u1_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(u1_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(u1_nd + b_py, npt.NDArray[np.uint8])
 assert_type(u1_nd + i_py, npt.NDArray[np.uint8])
@@ -308,6 +329,9 @@ assert_type(u2_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(u2_nd + u_nd, npt.NDArray[np.unsignedinteger])
 assert_type(u2_nd + f_nd, npt.NDArray[np.floating])
 assert_type(u2_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(u2_nd + iu_nd, npt.NDArray[np.integer])
+assert_type(u2_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(u2_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(u2_nd + b_py, npt.NDArray[np.uint16])
 assert_type(u2_nd + i_py, npt.NDArray[np.uint16])
@@ -348,6 +372,9 @@ assert_type(u4_nd + i_nd, npt.NDArray[np.int64])
 assert_type(u4_nd + u_nd, npt.NDArray[np.unsignedinteger])
 assert_type(u4_nd + f_nd, npt.NDArray[np.floating])
 assert_type(u4_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(u4_nd + iu_nd, npt.NDArray[np.integer])
+assert_type(u4_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(u4_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(u4_nd + b_py, npt.NDArray[np.uint32])
 assert_type(u4_nd + i_py, npt.NDArray[np.uint32])
@@ -388,6 +415,9 @@ assert_type(u8_nd + i_nd, npt.NDArray[np.float64])
 assert_type(u8_nd + u_nd, npt.NDArray[np.uint64])
 assert_type(u8_nd + f_nd, npt.NDArray[np.floating])
 assert_type(u8_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(u8_nd + iu_nd, npt.NDArray[np.uint64 | np.float64])
+assert_type(u8_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(u8_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(u8_nd + b_py, npt.NDArray[np.uint64])
 assert_type(u8_nd + i_py, npt.NDArray[np.uint64])
@@ -428,6 +458,9 @@ assert_type(f2_nd + i_nd, npt.NDArray[np.floating])
 assert_type(f2_nd + u_nd, npt.NDArray[np.floating])
 assert_type(f2_nd + f_nd, npt.NDArray[np.floating])
 assert_type(f2_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(f2_nd + iu_nd, npt.NDArray[np.floating])
+assert_type(f2_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(f2_nd + iufc_nd, npt.NDArray[np.inexact])
 
 assert_type(f2_nd + b_py, npt.NDArray[np.float16])
 assert_type(f2_nd + i_py, npt.NDArray[np.float16])
@@ -468,6 +501,9 @@ assert_type(f4_nd + i_nd, npt.NDArray[np.floating])
 assert_type(f4_nd + u_nd, npt.NDArray[np.floating])
 assert_type(f4_nd + f_nd, npt.NDArray[np.floating])
 assert_type(f4_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(f4_nd + iu_nd, npt.NDArray[np.floating])
+assert_type(f4_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(f4_nd + iufc_nd, npt.NDArray[np.inexact])
 
 assert_type(f4_nd + b_py, npt.NDArray[np.float32])
 assert_type(f4_nd + i_py, npt.NDArray[np.float32])
@@ -508,6 +544,9 @@ assert_type(f8_nd + i_nd, npt.NDArray[np.float64])
 assert_type(f8_nd + u_nd, npt.NDArray[np.float64])
 assert_type(f8_nd + f_nd, npt.NDArray[np.floating])
 assert_type(f8_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(f8_nd + iu_nd, npt.NDArray[np.float64])
+assert_type(f8_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(f8_nd + iufc_nd, npt.NDArray[np.inexact])
 
 assert_type(f8_nd + b_py, npt.NDArray[np.float64])
 assert_type(f8_nd + i_py, npt.NDArray[np.float64])
@@ -548,6 +587,9 @@ assert_type(fld_nd + i_nd, npt.NDArray[np.longdouble])
 assert_type(fld_nd + u_nd, npt.NDArray[np.longdouble])
 assert_type(fld_nd + f_nd, npt.NDArray[np.longdouble])
 assert_type(fld_nd + c_nd, npt.NDArray[np.clongdouble])
+assert_type(fld_nd + iu_nd, npt.NDArray[np.longdouble])
+assert_type(fld_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(fld_nd + iufc_nd, npt.NDArray[np.inexact])
 
 assert_type(fld_nd + b_py, npt.NDArray[np.longdouble])
 assert_type(fld_nd + i_py, npt.NDArray[np.longdouble])
@@ -588,6 +630,9 @@ assert_type(c8_nd + i_nd, npt.NDArray[np.complexfloating])
 assert_type(c8_nd + u_nd, npt.NDArray[np.complexfloating])
 assert_type(c8_nd + f_nd, npt.NDArray[np.complexfloating])
 assert_type(c8_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(c8_nd + iu_nd, npt.NDArray[np.complexfloating])
+assert_type(c8_nd + fc_nd, npt.NDArray[np.complexfloating])
+assert_type(c8_nd + iufc_nd, npt.NDArray[np.complexfloating])
 
 assert_type(c8_nd + b_py, npt.NDArray[np.complex64])
 assert_type(c8_nd + i_py, npt.NDArray[np.complex64])
@@ -628,6 +673,9 @@ assert_type(c16_nd + i_nd, npt.NDArray[np.complex128])
 assert_type(c16_nd + u_nd, npt.NDArray[np.complex128])
 assert_type(c16_nd + f_nd, npt.NDArray[np.complexfloating])
 assert_type(c16_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(c16_nd + iu_nd, npt.NDArray[np.complex128])
+assert_type(c16_nd + fc_nd, npt.NDArray[np.complexfloating])
+assert_type(c16_nd + iufc_nd, npt.NDArray[np.complexfloating])
 
 assert_type(c16_nd + b_py, npt.NDArray[np.complex128])
 assert_type(c16_nd + i_py, npt.NDArray[np.complex128])
@@ -668,6 +716,9 @@ assert_type(cld_nd + i_nd, npt.NDArray[np.clongdouble])
 assert_type(cld_nd + u_nd, npt.NDArray[np.clongdouble])
 assert_type(cld_nd + f_nd, npt.NDArray[np.clongdouble])
 assert_type(cld_nd + c_nd, npt.NDArray[np.clongdouble])
+assert_type(cld_nd + iu_nd, npt.NDArray[np.clongdouble])
+assert_type(cld_nd + fc_nd, npt.NDArray[np.clongdouble])
+assert_type(cld_nd + iufc_nd, npt.NDArray[np.clongdouble])
 
 assert_type(cld_nd + b_py, npt.NDArray[np.clongdouble])
 assert_type(cld_nd + i_py, npt.NDArray[np.clongdouble])
@@ -707,6 +758,9 @@ assert_type(M8_nd + i_nd, npt.NDArray[np.datetime64])
 assert_type(M8_nd + u_nd, npt.NDArray[np.datetime64])
 M8_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 M8_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(M8_nd + iu_nd, npt.NDArray[np.datetime64])
+M8_nd + fc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+M8_nd + iufc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 assert_type(M8_nd + b_py, npt.NDArray[np.datetime64])
 assert_type(M8_nd + i_py, npt.NDArray[np.datetime64])
@@ -746,6 +800,9 @@ assert_type(m8_nd + i_nd, npt.NDArray[np.timedelta64])
 assert_type(m8_nd + u_nd, npt.NDArray[np.timedelta64])
 m8_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 m8_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(m8_nd + iu_nd, npt.NDArray[np.timedelta64])
+m8_nd + fc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+m8_nd + iufc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 assert_type(m8_nd + b_py, npt.NDArray[np.timedelta64])
 assert_type(m8_nd + i_py, npt.NDArray[np.timedelta64])
@@ -783,6 +840,9 @@ assert_type(O_nd + i_nd, npt.NDArray[np.object_])
 assert_type(O_nd + u_nd, npt.NDArray[np.object_])
 assert_type(O_nd + f_nd, npt.NDArray[np.object_])
 assert_type(O_nd + c_nd, npt.NDArray[np.object_])
+assert_type(O_nd + iu_nd, npt.NDArray[np.object_])
+assert_type(O_nd + fc_nd, npt.NDArray[np.object_])
+assert_type(O_nd + iufc_nd, npt.NDArray[np.object_])
 
 assert_type(O_nd + b_py, npt.NDArray[np.object_])
 assert_type(O_nd + i_py, npt.NDArray[np.object_])
@@ -823,6 +883,9 @@ S_nd + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 S_nd + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 S_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 S_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + iu_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + fc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+S_nd + iufc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 S_nd + b_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 S_nd + i_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
@@ -863,6 +926,9 @@ U_nd + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 U_nd + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 U_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 U_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+U_nd + iu_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+U_nd + fc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+U_nd + iufc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 U_nd + b_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 U_nd + i_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
@@ -902,6 +968,9 @@ T_nd + i_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 T_nd + u_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 T_nd + f_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 T_nd + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+T_nd + iu_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+T_nd + fc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+T_nd + iufc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 
 T_nd + b_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
 T_nd + i_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
@@ -942,6 +1011,9 @@ assert_type(i_nd + i_nd, npt.NDArray[np.signedinteger])
 assert_type(i_nd + u_nd, npt.NDArray[np.signedinteger | np.float64])
 assert_type(i_nd + f_nd, npt.NDArray[np.floating])
 assert_type(i_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(i_nd + iu_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(i_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(i_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(i_nd + b_py, npt.NDArray[np.signedinteger])
 assert_type(i_nd + i_py, npt.NDArray[np.signedinteger])
@@ -982,6 +1054,9 @@ assert_type(u_nd + i_nd, npt.NDArray[np.signedinteger | np.float64])
 assert_type(u_nd + u_nd, npt.NDArray[np.unsignedinteger])
 assert_type(u_nd + f_nd, npt.NDArray[np.floating])
 assert_type(u_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(u_nd + iu_nd, npt.NDArray[np.integer | np.float64])
+assert_type(u_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(u_nd + iufc_nd, npt.NDArray[np.number])
 
 assert_type(u_nd + b_py, npt.NDArray[np.unsignedinteger])
 assert_type(u_nd + i_py, npt.NDArray[np.unsignedinteger])
@@ -1022,6 +1097,9 @@ assert_type(f_nd + i_nd, npt.NDArray[np.floating])
 assert_type(f_nd + u_nd, npt.NDArray[np.floating])
 assert_type(f_nd + f_nd, npt.NDArray[np.floating])
 assert_type(f_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(f_nd + iu_nd, npt.NDArray[np.floating])
+assert_type(f_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(f_nd + iufc_nd, npt.NDArray[np.inexact])
 
 assert_type(f_nd + b_py, npt.NDArray[np.floating])
 assert_type(f_nd + i_py, npt.NDArray[np.floating])
@@ -1062,6 +1140,9 @@ assert_type(c_nd + i_nd, npt.NDArray[np.complexfloating])
 assert_type(c_nd + u_nd, npt.NDArray[np.complexfloating])
 assert_type(c_nd + f_nd, npt.NDArray[np.complexfloating])
 assert_type(c_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + iu_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + fc_nd, npt.NDArray[np.complexfloating])
+assert_type(c_nd + iufc_nd, npt.NDArray[np.complexfloating])
 
 assert_type(c_nd + b_py, npt.NDArray[np.complexfloating])
 assert_type(c_nd + i_py, npt.NDArray[np.complexfloating])
@@ -1075,3 +1156,132 @@ assert_type(i_py + c_nd, npt.NDArray[np.complexfloating])
 assert_type(f_py + c_nd, npt.NDArray[np.complexfloating])
 assert_type(c_py + c_nd, npt.NDArray[np.complexfloating])
 U_py + c_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(iu_nd + b1_nd, npt.NDArray[np.integer])
+assert_type(iu_nd + i1_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(iu_nd + i2_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(iu_nd + i4_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(iu_nd + i8_nd, npt.NDArray[np.int64 | np.float64])
+assert_type(iu_nd + u1_nd, npt.NDArray[np.integer])
+assert_type(iu_nd + u2_nd, npt.NDArray[np.integer])
+assert_type(iu_nd + u4_nd, npt.NDArray[np.integer])
+assert_type(iu_nd + u8_nd, npt.NDArray[np.uint64 | np.float64])
+assert_type(iu_nd + f2_nd, npt.NDArray[np.floating])
+assert_type(iu_nd + f4_nd, npt.NDArray[np.floating])
+assert_type(iu_nd + f8_nd, npt.NDArray[np.float64])
+assert_type(iu_nd + fld_nd, npt.NDArray[np.longdouble])
+assert_type(iu_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(iu_nd + c16_nd, npt.NDArray[np.complex128])
+assert_type(iu_nd + cld_nd, npt.NDArray[np.clongdouble])
+assert_type(iu_nd + M8_nd, npt.NDArray[np.datetime64])
+assert_type(iu_nd + m8_nd, npt.NDArray[np.timedelta64])
+assert_type(iu_nd + O_nd, npt.NDArray[np.object_])
+iu_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iu_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iu_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(iu_nd + i_nd, npt.NDArray[np.signedinteger | np.float64])
+assert_type(iu_nd + u_nd, npt.NDArray[np.integer | np.float64])
+assert_type(iu_nd + f_nd, npt.NDArray[np.floating])
+assert_type(iu_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(iu_nd + iu_nd, npt.NDArray[np.integer | np.float64])
+assert_type(iu_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(iu_nd + iufc_nd, npt.NDArray[np.number])
+
+assert_type(iu_nd + b_py, npt.NDArray[np.integer])
+assert_type(iu_nd + i_py, npt.NDArray[np.integer])
+assert_type(iu_nd + f_py, npt.NDArray[np.float64])
+assert_type(iu_nd + c_py, npt.NDArray[np.complex128])
+iu_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iu_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + iu_nd, npt.NDArray[np.integer])
+assert_type(i_py + iu_nd, npt.NDArray[np.integer])
+assert_type(f_py + iu_nd, npt.NDArray[np.float64])
+assert_type(c_py + iu_nd, npt.NDArray[np.complex128])
+U_py + iu_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(fc_nd + b1_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + i1_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + i2_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + i4_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + i8_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + u1_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + u2_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + u4_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + u8_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + f2_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + f4_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + f8_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + fld_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(fc_nd + c16_nd, npt.NDArray[np.complexfloating])
+assert_type(fc_nd + cld_nd, npt.NDArray[np.clongdouble])
+fc_nd + M8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+fc_nd + m8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(fc_nd + O_nd, npt.NDArray[np.object_])
+fc_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+fc_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+fc_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(fc_nd + i_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + u_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + f_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(fc_nd + iu_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(fc_nd + iufc_nd, npt.NDArray[np.inexact])
+
+assert_type(fc_nd + b_py, npt.NDArray[np.inexact])
+assert_type(fc_nd + i_py, npt.NDArray[np.inexact])
+assert_type(fc_nd + f_py, npt.NDArray[np.inexact])
+assert_type(fc_nd + c_py, npt.NDArray[np.complexfloating])
+fc_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+fc_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + fc_nd, npt.NDArray[np.inexact])
+assert_type(i_py + fc_nd, npt.NDArray[np.inexact])
+assert_type(f_py + fc_nd, npt.NDArray[np.inexact])
+assert_type(c_py + fc_nd, npt.NDArray[np.complexfloating])
+U_py + fc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(iufc_nd + b1_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + i1_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + i2_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + i4_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + i8_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + u1_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + u2_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + u4_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + u8_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + f2_nd, npt.NDArray[np.inexact])
+assert_type(iufc_nd + f4_nd, npt.NDArray[np.inexact])
+assert_type(iufc_nd + f8_nd, npt.NDArray[np.inexact])
+assert_type(iufc_nd + fld_nd, npt.NDArray[np.inexact])
+assert_type(iufc_nd + c8_nd, npt.NDArray[np.complexfloating])
+assert_type(iufc_nd + c16_nd, npt.NDArray[np.complexfloating])
+assert_type(iufc_nd + cld_nd, npt.NDArray[np.clongdouble])
+iufc_nd + M8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iufc_nd + m8_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(iufc_nd + O_nd, npt.NDArray[np.object_])
+iufc_nd + S_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iufc_nd + U_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iufc_nd + T_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+assert_type(iufc_nd + i_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + u_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + f_nd, npt.NDArray[np.inexact])
+assert_type(iufc_nd + c_nd, npt.NDArray[np.complexfloating])
+assert_type(iufc_nd + iu_nd, npt.NDArray[np.number])
+assert_type(iufc_nd + fc_nd, npt.NDArray[np.inexact])
+assert_type(iufc_nd + iufc_nd, npt.NDArray[np.number])
+
+assert_type(iufc_nd + b_py, npt.NDArray[np.number])
+assert_type(iufc_nd + i_py, npt.NDArray[np.number])
+assert_type(iufc_nd + f_py, npt.NDArray[np.inexact])
+assert_type(iufc_nd + c_py, npt.NDArray[np.complexfloating])
+iufc_nd + S_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+iufc_nd + U_py  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]
+
+assert_type(b_py + iufc_nd, npt.NDArray[np.number])
+assert_type(i_py + iufc_nd, npt.NDArray[np.number])
+assert_type(f_py + iufc_nd, npt.NDArray[np.inexact])
+assert_type(c_py + iufc_nd, npt.NDArray[np.complexfloating])
+U_py + iufc_nd  # type: ignore[operator]  # pyright: ignore[reportOperatorIssue]

--- a/tool/testgen.py
+++ b/tool/testgen.py
@@ -176,30 +176,35 @@ def _sctype_expr_from_value(value: _Scalar | tuple[_Scalar, ...], /) -> str:
     return type(value).__qualname__
 
 
-def _dtype_expr(dtype: np.dtype, /) -> str:
-    if dtype.char == "T":
-        return f"{NP}.dtypes.StringDType"
-    sctype_expr = _sctype_expr(dtype)
-    return f"{NP}.dtype[{sctype_expr}]"
+def _array_expr(*dtypes: np.dtype, ndim: int | None = None, npt: bool = False) -> str:
+    assert dtypes
 
+    chars = {dtype.char for dtype in dtypes}
+    kinds = {dtype.char for dtype in dtypes}
+    assert len(chars) == 1 or kinds - {"i", "u", "f", "c", "ui", "fc", "iufc"}, (
+        "unsupported multiple dtypes"
+    )
 
-def _array_expr(
-    dtype: np.dtype,
-    /,
-    *,
-    ndim: int | None = None,
-    npt: bool = False,
-) -> str:
-    if ndim is None and npt and dtype.char != "T":
-        return f"npt.NDArray[{_sctype_expr(dtype)}]"
+    if "T" in chars:
+        assert len(chars) == 1
+        dtype_expr = f"{NP}.dtypes.StringDType"
+    else:
+        sctype_exprs = [_sctype_expr(dtype) for dtype in dtypes]
+        if len(sctype_exprs) == 1:
+            sctype_expr = sctype_exprs[0]
+        else:
+            sctype_expr = _join(*sctype_exprs)
+
+        if ndim is None and npt:
+            return f"npt.NDArray[{sctype_expr}]"
+
+        dtype_expr = f"{NP}.dtype[{sctype_expr}]"
 
     if ndim is None:
         shape_expr = "tuple[int, ...]"
     else:
         shape_expr_args = ", ".join(["int"] * ndim) if ndim else "()"
         shape_expr = f"tuple[{shape_expr_args}]"
-
-    dtype_expr = _dtype_expr(dtype)
 
     return f"{NP}.ndarray[{shape_expr}, {dtype_expr}]"
 
@@ -1084,7 +1089,7 @@ class NDArrayOps(TestGen):
 
     opname: _OpName
     opfunc: Callable[..., Any]
-    dtypes: list[np.dtype]
+    dtypes: dict[str, tuple[np.dtype, ...]]
 
     def __init__(self, opname: _OpName, /) -> None:
         ufunc = OP_UFUNCS[opname]
@@ -1098,32 +1103,58 @@ class NDArrayOps(TestGen):
             self.opfunc = getattr(op, opname, None) or getattr(op, opname + "_")
         self.testname = self.testname.format(opname)
 
-        dtypes_seen: set[str] = set()
-        self.dtypes = []
+        seen_dtypes: set[str] = set()
+
+        unseen_abstract = {
+            "i": {dtype_label(np.dtype(f"i{nbit}")) for nbit in (1, 2, 4, 8)},
+            "u": {dtype_label(np.dtype(f"u{nbit}")) for nbit in (1, 2, 4, 8)},
+            "f": {dtype_label(np.dtype(char)) for char in "efdg"},
+            "c": {dtype_label(np.dtype(char)) for char in "FDG"},
+        }
+        seen_abstract: dict[str, list[np.dtype]] = {
+            kind: [] for kind in unseen_abstract
+        }
+
+        self.dtypes = {}
+
+        # concrete dtypes
         for dtype in sorted(
             _get_op_types(opname),
             key=lambda dt: DTYPE_CHARS.index(dt.char),
         ):
             label = dtype_label(dtype)
-            if label in dtypes_seen:
+            if label in seen_dtypes:
                 continue
-            dtypes_seen.add(label)
+            seen_dtypes.add(label)
 
-            if dtype not in dtypes_seen:
-                self.dtypes.append(dtype)
+            kind = dtype.kind
+            if kind in "SU":
+                kind = "w"
+            if kind in unseen_abstract and label in unseen_abstract[kind]:
+                unseen_abstract[kind].remove(label)
+                seen_abstract[kind].append(dtype)
+
+            self.dtypes[label] = (dtype,)
+
+        # abstract dtypes
+        for kind, dtypes in seen_abstract.items():
+            if unseen_abstract[kind]:
+                continue
+
+            assert dtypes
+            assert kind not in self.dtypes
+
+            self.dtypes[kind] = tuple(dtypes)
 
         super().__init__()
 
     @property
     def _scalars_py(self) -> Mapping[str, type[complex | bytes | str]]:
         kindmap = {"b": bool, "i": int, "f": float, "c": complex, "S": bytes, "U": str}
-        kinds = {dtype.kind: "" for dtype in self.dtypes}
+        kinds = {
+            dtypes[0].kind: "" for dtypes in self.dtypes.values() if len(dtypes) == 1
+        }
         return {f"{kind}_py": kindmap[kind] for kind in kinds if kind in kindmap}
-
-    def _op_expr(self, lhs: str, rhs: str, /) -> str:
-        if self.opfunc.__name__ == "divmod":
-            return f"divmod({lhs}, {rhs})"
-        return lhs + str(self.opfunc.__doc__)[9:-2] + rhs
 
     @staticmethod
     def _get_arrays(
@@ -1142,53 +1173,76 @@ class NDArrayOps(TestGen):
 
         return arr1, arr2
 
-    @override
-    def get_names(self) -> Iterable[tuple[str, str]]:
-        # ndarays
-        for dtype in self.dtypes:
-            yield f"{dtype_label(dtype)}_nd", _array_expr(dtype, npt=True)
+    @staticmethod
+    def _abstract_expr(label: str, /) -> str:
+        sctype_name = {
+            "i": "signedinteger",
+            "u": "unsignedinteger",
+            "f": "floating",
+            "c": "complexfloating",
+            "iu": "integer",
+            "fc": "inexact",
+            "iufc": "number",
+        }[label]
+        return f"{NP}.{sctype_name}"
 
-        yield "", ""  # linebreak
+    def _op_expr(self, lhs: str, rhs: str, /) -> str:
+        if self.opfunc.__name__ == "divmod":
+            return f"divmod({lhs}, {rhs})"
+        return lhs + str(self.opfunc.__doc__)[9:-2] + rhs
 
-        # python scalars
-        for name, pytype in self._scalars_py.items():
-            yield name, pytype.__name__
+    def _evaluate(
+        self,
+        lhs: npt.ArrayLike,
+        rhs: npt.ArrayLike,
+        /,
+        *,
+        reflect: bool = False,
+    ) -> np.dtype | None:
+        if reflect:
+            lhs, rhs = rhs, lhs
 
-    def _gen_testcases_np_nd(self, dtype1: np.dtype, /) -> Generator[str | None]:
-        name1 = f"{dtype_label(dtype1)}_nd"
+        try:
+            return self.opfunc(lhs, rhs).dtype
+        except TypeError:
+            return None
 
-        for dtype2 in self.dtypes:
-            name2 = f"{dtype_label(dtype2)}_nd"
+    def _gen_testcases_np_nd(self, label1: str, /) -> Generator[str | None]:
+        name1 = f"{label1}_nd"
+        dtypes1 = self.dtypes[label1]
+
+        for label2, dtypes2 in self.dtypes.items():
+            name2 = f"{label2}_nd"
             expr = self._op_expr(name1, name2)
 
-            arr1, arr2 = self._get_arrays(dtype1, dtype2)
+            out_dtypes: set[np.dtype] = set()
+            for dtype1, dtype2 in itertools.product(dtypes1, dtypes2):
+                arr1, arr2 = self._get_arrays(dtype1, dtype2)
 
-            try:
-                out = self.opfunc(arr1, arr2)
-            except TypeError:
-                if "O" in dtype1.char + dtype2.char:
-                    # impossible to reject
-                    continue
+                if (out_dtype := self._evaluate(arr1, arr2)) is None:
+                    out_dtypes.clear()
+                    break
+                out_dtypes.add(out_dtype)
 
-                testcase = "  ".join((  # noqa: FLY002
+            if out_dtypes:
+                out_type_expr = _array_expr(*out_dtypes, npt=True)
+                yield _expr_assert_type(expr, out_type_expr)
+            elif "O" not in {dtypes1[0].char, dtypes2[0].char}:  # impossible to reject
+                yield "  ".join((  # noqa: FLY002
                     expr,
                     "# type: ignore[operator]",
                     "# pyright: ignore[reportOperatorIssue]",
                 ))
-            else:
-                out_type_expr = _array_expr(out.dtype, npt=True)
-                testcase = _expr_assert_type(expr, out_type_expr)
-
-            yield testcase
 
     def _gen_testcases_py_0d(
         self,
-        dtype: np.dtype,
+        label_np: str,
         /,
         *,
         reflect: bool = False,
     ) -> Generator[str | None]:
-        name_np = f"{dtype_label(dtype)}_nd"
+        name_np = f"{label_np}_nd"
+        dtypes_np = self.dtypes[label_np]
 
         for name_py, pytype in self._scalars_py.items():
             if reflect and pytype is bytes:
@@ -1197,35 +1251,59 @@ class NDArrayOps(TestGen):
 
             name1, name2 = (name_py, name_np) if reflect else (name_np, name_py)
 
-            val_np, val_py = self._get_arrays(dtype, np.dtype(pytype))[0], pytype(1)
-            val1, val2 = (val_py, val_np) if reflect else (val_np, val_py)
+            dtype_py, val_py = np.dtype(pytype), pytype(1)
+
+            out_dtypes: set[np.dtype] = set()
+            for dtype_np in dtypes_np:
+                arr = self._get_arrays(dtype_np, dtype_py)[0]
+
+                if (out_dtype := self._evaluate(arr, val_py, reflect=reflect)) is None:
+                    out_dtypes.clear()
+                    break
+                out_dtypes.add(out_dtype)
 
             expr = self._op_expr(name1, name2)
 
-            try:
-                out = self.opfunc(val1, val2)
-            except TypeError:
+            if out_dtypes:
+                out_type_expr = _array_expr(*out_dtypes, npt=True)
+                testcase = _expr_assert_type(expr, out_type_expr)
+            else:
                 testcase = "  ".join((  # noqa: FLY002
                     expr,
                     "# type: ignore[operator]",
                     "# pyright: ignore[reportOperatorIssue]",
                 ))
-            else:
-                out_type_expr = _array_expr(out.dtype, npt=True)
-                testcase = _expr_assert_type(expr, out_type_expr)
 
             yield testcase
+
+    @override
+    def get_names(self) -> Iterable[tuple[str, str]]:
+        # ndarays
+
+        for label, dtypes in self.dtypes.items():
+            if len(dtypes) == 1:
+                array_expr = _array_expr(dtypes[0], npt=True)
+            else:
+                array_expr = f"npt.NDArray[{self._abstract_expr(label)}]"
+
+            yield f"{label}_nd", array_expr
+
+        yield "", ""  # linebreak
+
+        # python scalars
+        for name, pytype in self._scalars_py.items():
+            yield name, pytype.__name__
 
     @override
     def get_testcases(self) -> Iterable[str | None]:
         yield from self._generate_section()
 
-        for dtype in self.dtypes:
-            yield from self._gen_testcases_np_nd(dtype)
+        for label in self.dtypes:
+            yield from self._gen_testcases_np_nd(label)
             yield ""
-            yield from self._gen_testcases_py_0d(dtype)
+            yield from self._gen_testcases_py_0d(label)
             yield ""
-            yield from self._gen_testcases_py_0d(dtype, reflect=True)
+            yield from self._gen_testcases_py_0d(label, reflect=True)
             yield ""
 
 

--- a/tool/testgen.py
+++ b/tool/testgen.py
@@ -1167,7 +1167,7 @@ class NDArrayOps(TestGen):
                 continue
             seen_dtypes.add(label)
 
-            kind = dtype.kind
+            kind: str = dtype.kind
             if kind in "SU":
                 kind = "w"
             if kind in unseen_abstract and label in unseen_abstract[kind]:
@@ -1209,9 +1209,11 @@ class NDArrayOps(TestGen):
             lhs, rhs = rhs, lhs
 
         try:
-            return self.opfunc(lhs, rhs).dtype
+            dtype: np.dtype = self.opfunc(lhs, rhs).dtype
         except TypeError:
             return None
+
+        return dtype
 
     def _gen_testcases_np_nd(self, label1: str, /) -> Generator[str | None]:
         name1 = f"{label1}_nd"


### PR DESCRIPTION
closes #488
towards #491

---

All of the newly generated tests pass without having to change the stubs 😎 