### PR TITLE
Fix unsupported glob pattern in pyproject.toml and add changelog entry

### DIFF
--- a/docs/dev/CHANGELOG.md
+++ b/docs/dev/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Fix unsupported glob pattern in pyproject.toml exclude list
+
+- The exclude pattern "**/@test" in the `[tool.hatch.build]` section of `pyproject.toml` caused an "Unsupported glob expression" error when using the uv_build backend.
+- Updated the pattern to the more specific `"src/**/@test/**"` to avoid the error and correctly exclude the in-package `@test` directories.
+- This change ensures compatibility with the uv_build backend's glob pattern parser while maintaining the intended exclusion of test directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dev = [
 
 [tool.hatch.build]
 exclude = [
-    "**/@test",
+    "src/**/@test/**",
     "**/*.yml",
     "**/.*",
     "/docs",


### PR DESCRIPTION
### Summary

___

This pull request resolves an "Unsupported glob expression" error in `pyproject.toml` caused by the invalid exclude pattern `"/@test"`. The pattern has been updated to `"src//@test/**"` in the `[tool.hatch.build.exclude]` section to ensure compatibility with the `uv_build` backend and proper exclusion of in-package `@test` directories.

### Changes Made

- Updated the glob pattern in `pyproject.toml` to avoid build errors with `uv_build`.
- Added a changelog entry in `docs/dev/CHANGELOG.md` documenting the issue and the applied fix.

### Context

The previous pattern was not supported by the `uv_build` backend, resulting in build failures. This fix aligns with expected glob syntax and ensures smooth packaging and distribution.

