### PR TITLE
🔨 only delete `__init__.pyi` when "unstubbing"

### DIFF
--- a/tool/stubtest.py
+++ b/tool/stubtest.py
@@ -71,7 +71,9 @@ __check_simd()
 
 def __commit_pyi_genocide_for_mypy() -> None:
     """
-    Remove the ``py.typed`` and all ``*.pyi`` files from the installed numpy package.
+    Remove all ``__init__.pyi`` files from the installed numpy package.
+
+    This works around https://github.com/python/mypy/issues/18997 on `mypy<1.16.0`.
 
     Raises
     ------
@@ -82,15 +84,9 @@ def __commit_pyi_genocide_for_mypy() -> None:
     if not package.is_dir():
         raise NotADirectoryError(f"{package} does not exist")
 
-    py_typed = package / "py.typed"
-    if py_typed.is_file():
-        py_typed.unlink()
-        if VERBOSE:
-            print(f"deleted {py_typed} (1)")
-
-    graveyard_size = sum(not pyi.unlink() for pyi in package.rglob("*.pyi"))  # type: ignore[func-returns-value]
+    graveyard_size = sum(not pyi.unlink() for pyi in package.rglob("__init__.pyi"))  # type: ignore[func-returns-value]
     if VERBOSE and graveyard_size:
-        print(f"deleted {package}/**/*.pyi ({graveyard_size})\n")
+        print(f"deleted {graveyard_size} __init__.pyi from {package}\n")
 
 
 def _allowlists() -> list[str]:

--- a/tool/unstub.py
+++ b/tool/unstub.py
@@ -1,5 +1,7 @@
 """
-Delete all `.pyi` files in the `numpy` site-packages directory.
+Delete all `__init__.pyi` files in the `numpy` site-packages directory.
+
+This is a workaround for https://github.com/python/mypy/issues/18997 on `mypy<1.16.0`
 
 Run with `uv run tool/unstub.py`.
 """
@@ -10,6 +12,5 @@ from pathlib import Path
 package = Path(sysconfig.get_paths()["purelib"]) / "numpy"
 assert package.is_dir(), package
 
-(package / "py.typed").unlink(missing_ok=True)
-bodycount = sum(not pyi.unlink() for pyi in package.rglob("*.pyi"))  # type: ignore[func-returns-value]
-print(f"{bodycount} files deleted from {package.relative_to(Path.cwd())}/**/*.pyi")
+bodycount = sum(not pyi.unlink() for pyi in package.rglob("__init__.pyi"))  # type: ignore[func-returns-value]
+print(f"{bodycount} files deleted from {package.relative_to(Path.cwd())}")


### PR DESCRIPTION
As workaround for python/mypy#18997