### PR TITLE
🔧 fix renovate config validation error

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -9,6 +9,6 @@
     "description": "lockFileMaintenance",
     "matchUpdateTypes": ["lockFileMaintenance", "pep723"],
     "dependencyDashboardApproval": false,
-    "minimumReleaseAge": 0
+    "minimumReleaseAge": "0"
   }]
 }


### PR DESCRIPTION
this fixes

```
 WARN: Config validation errors found
       "configType": "/github-action/renovate-config.json",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Configuration option `packageRules[0].minimumReleaseAge` should be a string"
         }
       ]
```