### PR TITLE
👽️ Port the recent _core and lib numpy typing PRs

### DIFF
--- a/src/numpy-stubs/__init__.pyi
+++ b/src/numpy-stubs/__init__.pyi
@@ -335,7 +335,7 @@ from ._core.umath import (
     vecmat,
 )
 from ._expired_attrs_2_0 import __expired_attributes__ as __expired_attributes__
-from ._globals import _CopyMode
+from ._globals import _CopyMode as _CopyMode, _NoValue as _NoValue
 from ._pytesttester import PytestTester
 from ._typing import (
     ArrayLike,

--- a/src/numpy-stubs/_core/_multiarray_umath.pyi
+++ b/src/numpy-stubs/_core/_multiarray_umath.pyi
@@ -1387,14 +1387,14 @@ def unravel_index(
 #
 @overload
 def ravel_multi_index(
-    multi_index: Sequence[_ToInt],
+    multi_index: SupportsLenAndGetItem[_ToInt],
     dims: _ShapeLike,
     mode: _ModeKind | tuple[_ModeKind, ...] = "raise",
     order: _OrderCF = "C",
 ) -> np.intp: ...
 @overload
 def ravel_multi_index(
-    multi_index: Sequence[_nt.ToInteger_1nd],
+    multi_index: SupportsLenAndGetItem[_nt.ToInteger_1nd],
     dims: _ShapeLike,
     mode: _ModeKind | tuple[_ModeKind, ...] = "raise",
     order: _OrderCF = "C",

--- a/src/numpy-stubs/_core/fromnumeric.pyi
+++ b/src/numpy-stubs/_core/fromnumeric.pyi
@@ -674,7 +674,7 @@ def sum(
 #
 @overload  # workaround for microsoft/pyright#10232
 def all(
-    a: _nt._ToArray_nnd[Any],
+    a: _nt._ToArray_nnd[Any] | None,
     axis: None = None,
     out: None = None,
     keepdims: _Option[L[False, 0]] = ...,
@@ -683,7 +683,7 @@ def all(
 ) -> np.bool: ...
 @overload
 def all(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: None = None,
     out: None = None,
     keepdims: _Option[L[False, 0]] = ...,
@@ -701,7 +701,7 @@ def all(
 ) -> np.bool | _nt.Array[np.bool]: ...
 @overload
 def all(
-    a: _nt.ToGeneric_1ds,
+    a: _nt.ToGeneric_1ds | None,
     axis: int | None = None,
     out: None = None,
     keepdims: _Option[L[False, 0]] = ...,
@@ -728,7 +728,7 @@ def all(
 ) -> _nt.Array[np.bool]: ...
 @overload
 def all(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: int | tuple[int, ...] | None = None,
     out: None = None,
     keepdims: _Option[_nt.ToBool_0d] = ...,
@@ -737,7 +737,7 @@ def all(
 ) -> np.bool | _nt.Array[np.bool]: ...
 @overload
 def all(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: int | tuple[int, ...] | None,
     out: _ArrayT,
     keepdims: _Option[_nt.ToBool_0d] = ...,
@@ -746,7 +746,7 @@ def all(
 ) -> _ArrayT: ...
 @overload
 def all(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: int | tuple[int, ...] | None = None,
     *,
     out: _ArrayT,
@@ -757,7 +757,7 @@ def all(
 # keep in sync with `all`
 @overload  # workaround for microsoft/pyright#10232
 def any(
-    a: _nt._ToArray_nnd[Any],
+    a: _nt._ToArray_nnd[Any] | None,
     axis: None = None,
     out: None = None,
     keepdims: _Option[L[False, 0]] = ...,
@@ -766,7 +766,7 @@ def any(
 ) -> np.bool: ...
 @overload
 def any(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: None = None,
     out: None = None,
     keepdims: _Option[L[False, 0]] = ...,
@@ -784,7 +784,7 @@ def any(
 ) -> np.bool | _nt.Array[np.bool]: ...
 @overload
 def any(
-    a: _nt.ToGeneric_1ds,
+    a: _nt.ToGeneric_1ds | None,
     axis: int | None = None,
     out: None = None,
     keepdims: _Option[L[False, 0]] = ...,
@@ -811,7 +811,7 @@ def any(
 ) -> _nt.Array[np.bool]: ...
 @overload
 def any(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: int | tuple[int, ...] | None = None,
     out: None = None,
     keepdims: _Option[_nt.ToBool_0d] = ...,
@@ -820,7 +820,7 @@ def any(
 ) -> np.bool | _nt.Array[np.bool]: ...
 @overload
 def any(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: int | tuple[int, ...] | None,
     out: _ArrayT,
     keepdims: _Option[_nt.ToBool_0d] = ...,
@@ -829,7 +829,7 @@ def any(
 ) -> _ArrayT: ...
 @overload
 def any(
-    a: ArrayLike,
+    a: ArrayLike | None,
     axis: int | tuple[int, ...] | None = None,
     *,
     out: _ArrayT,

--- a/src/numpy-stubs/_core/overrides.pyi
+++ b/src/numpy-stubs/_core/overrides.pyi
@@ -1,12 +1,12 @@
 from collections.abc import Callable, Iterable
-from typing import Any, Final, NamedTuple
+from typing import Any, Final, NamedTuple, TypeAlias
 from typing_extensions import ParamSpec, TypeVar
-
-from numpy._typing import _SupportsArrayFunc
 
 _T = TypeVar("_T")
 _Tss = ParamSpec("_Tss")
-_FuncT = TypeVar("_FuncT", bound=Callable[..., object])
+_FuncLikeT = TypeVar("_FuncLikeT", bound=type | Callable[..., object])
+
+_Dispatcher: TypeAlias = Callable[_Tss, Iterable[object]]
 
 ###
 
@@ -20,12 +20,10 @@ class ArgSpec(NamedTuple):
     defaults: tuple[Any, ...]
 
 def get_array_function_like_doc(public_api: Callable[..., object], docstring_template: str = "") -> str: ...
-def finalize_array_function_like(public_api: _FuncT) -> _FuncT: ...
+def finalize_array_function_like(public_api: _FuncLikeT) -> _FuncLikeT: ...
 
 #
-def verify_matching_signatures(
-    implementation: Callable[_Tss, object], dispatcher: Callable[_Tss, Iterable[_SupportsArrayFunc]]
-) -> None: ...
+def verify_matching_signatures(implementation: Callable[_Tss, object], dispatcher: _Dispatcher[_Tss]) -> None: ...
 
 # NOTE: This actually returns a `_ArrayFunctionDispatcher` callable wrapper object, with
 # the original wrapped callable stored in the `._implementation` attribute. It checks
@@ -38,11 +36,11 @@ def verify_matching_signatures(
 # implement, ignoring the many hours that I and other stub maintainers are now losing
 # because of this completely unreasonable restriction).
 def array_function_dispatch(
-    dispatcher: Callable[_Tss, Iterable[_SupportsArrayFunc]] | None = None,
+    dispatcher: _Dispatcher[_Tss] | None = None,
     module: str | None = None,
     verify: bool = True,
     docs_from_dispatcher: bool = False,
-) -> Callable[[_FuncT], _FuncT]: ...
+) -> Callable[[_FuncLikeT], _FuncLikeT]: ...
 
 #
 def array_function_from_dispatcher(
@@ -50,4 +48,4 @@ def array_function_from_dispatcher(
     module: str | None = None,
     verify: bool = True,
     docs_from_dispatcher: bool = True,
-) -> Callable[[Callable[_Tss, Iterable[_SupportsArrayFunc]]], Callable[_Tss, _T]]: ...
+) -> Callable[[_Dispatcher[_Tss]], Callable[_Tss, _T]]: ...

--- a/src/numpy-stubs/lib/_iotools.pyi
+++ b/src/numpy-stubs/lib/_iotools.pyi
@@ -1,14 +1,15 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, ClassVar, Final, Literal as L, TypedDict, overload, type_check_only
 from typing_extensions import TypeVar, Unpack
 
 import numpy as np
 import numpy.typing as npt
+from numpy._typing._dtype_like import _DTypeLikeNested
 
 _T = TypeVar("_T")
 
 @type_check_only
-class _ValidationKwargs(TypedDict, total=False):
+class _NameValidatorKwargs(TypedDict, total=False):
     excludelist: Iterable[str] | None
     deletechars: Iterable[str] | None
     case_sensitive: L["upper", "lower"] | bool | None
@@ -16,7 +17,7 @@ class _ValidationKwargs(TypedDict, total=False):
 
 ###
 
-__docformat__: Final[str] = "restructuredtext en"
+__docformat__: Final = "restructuredtext en"
 
 class ConverterError(Exception): ...
 class ConverterLockError(ConverterError): ...
@@ -94,6 +95,9 @@ class StringConverter:
     @classmethod
     def upgrade_mapper(cls, func: Callable[[str], Any], default: object | None = None) -> None: ...
 
+def _decode_line(line: str | bytes, encoding: str | None = None) -> str: ...
+def _is_string_like(obj: object) -> bool: ...
+def _is_bytes_like(obj: object) -> bool: ...
 @overload
 def str2bool(value: L["false", "False", "FALSE"]) -> L[False]: ...
 @overload
@@ -109,8 +113,8 @@ def flatten_dtype(
 
 #
 def easy_dtype(
-    ndtype: npt.DTypeLike,
-    names: Iterable[str] | None = None,
+    ndtype: str | Sequence[_DTypeLikeNested],
+    names: str | Sequence[str] | None = None,
     defaultfmt: str = "f%i",
-    **validationargs: Unpack[_ValidationKwargs],
+    **validationargs: Unpack[_NameValidatorKwargs],
 ) -> np.dtype[np.void]: ...


### PR DESCRIPTION
This ports the following upstream changes:

- numpy/numpy#29170
- numpy/numpy#29171
- numpy/numpy#29176
- numpy/numpy#29177
- numpy/numpy#29184

Closes #581