### PR TITLE
Fix CLI args to match docstring usage (remove -f flag)

### DIFF
--- a/tool/promotion.py
+++ b/tool/promotion.py
@@ -187,9 +187,8 @@ def _parse_args(args: Sequence[str] | None, /) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="promotion.py")
 
     parser.add_argument(
-        "-f",
-        "--format",
-        type=str,
+        "format",
+        nargs="?",
         choices=["table", "graph"],
         default="table",
         help="display format",


### PR DESCRIPTION
This PR updates the argument parsing in tool/promotion.py to match the usage instructions in the docstring.

## Changes:

Changed the format argument from a flag (-f/--format) to an optional positional argument.

Removed the redundant type=str.

Result: The command can now be run exactly as documented: uv run tool/promotion.py table

Fixes #747