### PR TITLE
🔨 list outdated outdated local stubs compared to upstream

### DIFF
--- a/tool/compare_upstream.py
+++ b/tool/compare_upstream.py
@@ -1,0 +1,83 @@
+"""List local numpy-stubs that are older than NumPy."""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+UPSTREAM_URL = "https://github.com/numpy/numpy.git"
+UPSTREAM_BRANCH = "maintenance/2.4.x"
+LOCAL_STUBS_ROOT = Path(__file__).resolve().parents[1] / "src" / "numpy-stubs"
+GIT_BIN = shutil.which("git") or "git"
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    proc = subprocess.run(
+        [GIT_BIN, *args], cwd=cwd, check=False, capture_output=True, text=True
+    )
+    proc.check_returncode()
+    return proc.stdout.strip()
+
+
+def _latest_commit_ts(repo: Path, path: Path) -> int | None:
+    rel = path.relative_to(repo)
+    out = _run_git(["log", "-1", "--format=%ct", "--", str(rel)], cwd=repo)
+    return int(out)
+
+
+def _list_outdated(local_repo: Path, upstream_repo: Path) -> list[str]:
+    outdated: list[str] = []
+    for local_file in LOCAL_STUBS_ROOT.rglob("*.pyi"):
+        rel = local_file.relative_to(LOCAL_STUBS_ROOT)
+        upstream_file = upstream_repo / "numpy" / rel
+        if not upstream_file.exists():
+            continue
+
+        ts_local = _latest_commit_ts(local_repo, local_file)
+        ts_upstream = _latest_commit_ts(upstream_repo, upstream_file)
+        if ts_upstream is None:
+            continue
+
+        if ts_local is None or ts_upstream > ts_local:
+            if local_file.read_bytes() == upstream_file.read_bytes():
+                continue
+            outdated.append(str(rel))
+
+    return sorted(outdated)
+
+
+def _main() -> int:
+    local_repo = Path(__file__).resolve().parents[1]
+    if not LOCAL_STUBS_ROOT.is_dir():
+        print(f"Local stubs not found at {LOCAL_STUBS_ROOT}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        print(f"Cloning upstream {UPSTREAM_BRANCH}...", file=sys.stderr)
+        _run_git(
+            [
+                "clone",
+                "--depth=1",
+                "--branch",
+                UPSTREAM_BRANCH,
+                UPSTREAM_URL,
+                str(tmp_path),
+            ],
+            cwd=tmp_path,
+        )
+        outdated = _list_outdated(local_repo, tmp_path)
+
+    if outdated:
+        print("Upstream is newer for:")
+        for rel in outdated:
+            print(f"https://github.com/numpy/numpy/blob/{UPSTREAM_BRANCH}/numpy/{rel}")
+    else:
+        print("All tracked stubs are up-to-date relative to upstream.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())


### PR DESCRIPTION
Currently, these are (115):

- [`__config__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/__config__.pyi)
- [`_array_api_info.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_array_api_info.pyi)
- [`_core/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/__init__.pyi)
- [`_core/_asarray.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_asarray.pyi)
- [`_core/_dtype.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_dtype.pyi)
- [`_core/_exceptions.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_exceptions.pyi)
- [`_core/_internal.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_internal.pyi)
- [`_core/_simd.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_simd.pyi)
- [`_core/_type_aliases.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_type_aliases.pyi)
- [`_core/_ufunc_config.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/_ufunc_config.pyi)
- [`_core/arrayprint.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/arrayprint.pyi)
- [`_core/defchararray.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/defchararray.pyi)
- [`_core/einsumfunc.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/einsumfunc.pyi)
- [`_core/fromnumeric.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/fromnumeric.pyi)
- [`_core/function_base.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/function_base.pyi)
- [`_core/getlimits.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/getlimits.pyi)
- [`_core/memmap.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/memmap.pyi)
- [`_core/multiarray.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/multiarray.pyi)
- [`_core/numeric.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/numeric.pyi)
- [`_core/numerictypes.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/numerictypes.pyi)
- [`_core/overrides.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/overrides.pyi)
- [`_core/records.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/records.pyi)
- [`_core/shape_base.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/shape_base.pyi)
- [`_core/strings.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/strings.pyi)
- [`_core/umath.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_core/umath.pyi)
- [`_expired_attrs_2_0.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_expired_attrs_2_0.pyi)
- [`_pytesttester.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_pytesttester.pyi)
- [`_typing/_ufunc.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_typing/_ufunc.pyi)
- [`_utils/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_utils/__init__.pyi)
- [`_utils/_inspect.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_utils/_inspect.pyi)
- [`_utils/_pep440.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/_utils/_pep440.pyi)
- [`char/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/char/__init__.pyi)
- [`core/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/core/__init__.pyi)
- [`core/_dtype.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/core/_dtype.pyi)
- [`core/_dtype_ctypes.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/core/_dtype_ctypes.pyi)
- [`core/overrides.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/core/overrides.pyi)
- [`distutils/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/distutils/__init__.pyi)
- [`dtypes.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/dtypes.pyi)
- [`exceptions.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/exceptions.pyi)
- [`f2py/_backends/_distutils.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/f2py/_backends/_distutils.pyi)
- [`f2py/auxfuncs.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/f2py/auxfuncs.pyi)
- [`f2py/crackfortran.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/f2py/crackfortran.pyi)
- [`f2py/f2py2e.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/f2py/f2py2e.pyi)
- [`f2py/symbolic.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/f2py/symbolic.pyi)
- [`f2py/use_rules.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/f2py/use_rules.pyi)
- [`fft/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/fft/__init__.pyi)
- [`fft/_helper.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/fft/_helper.pyi)
- [`fft/_pocketfft.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/fft/_pocketfft.pyi)
- [`lib/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/__init__.pyi)
- [`lib/_array_utils_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_array_utils_impl.pyi)
- [`lib/_arraypad_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_arraypad_impl.pyi)
- [`lib/_arraysetops_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_arraysetops_impl.pyi)
- [`lib/_arrayterator_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_arrayterator_impl.pyi)
- [`lib/_datasource.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_datasource.pyi)
- [`lib/_format_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_format_impl.pyi)
- [`lib/_function_base_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_function_base_impl.pyi)
- [`lib/_histograms_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_histograms_impl.pyi)
- [`lib/_index_tricks_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_index_tricks_impl.pyi)
- [`lib/_iotools.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_iotools.pyi)
- [`lib/_nanfunctions_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_nanfunctions_impl.pyi)
- [`lib/_npyio_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_npyio_impl.pyi)
- [`lib/_polynomial_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_polynomial_impl.pyi)
- [`lib/_scimath_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_scimath_impl.pyi)
- [`lib/_shape_base_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_shape_base_impl.pyi)
- [`lib/_stride_tricks_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_stride_tricks_impl.pyi)
- [`lib/_twodim_base_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_twodim_base_impl.pyi)
- [`lib/_type_check_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_type_check_impl.pyi)
- [`lib/_ufunclike_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_ufunclike_impl.pyi)
- [`lib/_user_array_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_user_array_impl.pyi)
- [`lib/_utils_impl.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_utils_impl.pyi)
- [`lib/_version.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/_version.pyi)
- [`lib/format.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/format.pyi)
- [`lib/introspect.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/introspect.pyi)
- [`lib/mixins.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/mixins.pyi)
- [`lib/npyio.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/npyio.pyi)
- [`lib/recfunctions.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/recfunctions.pyi)
- [`lib/scimath.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/scimath.pyi)
- [`lib/stride_tricks.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/lib/stride_tricks.pyi)
- [`linalg/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/linalg/__init__.pyi)
- [`linalg/_linalg.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/linalg/_linalg.pyi)
- [`linalg/_umath_linalg.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/linalg/_umath_linalg.pyi)
- [`linalg/lapack_lite.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/linalg/lapack_lite.pyi)
- [`ma/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/ma/__init__.pyi)
- [`ma/core.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/ma/core.pyi)
- [`ma/extras.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/ma/extras.pyi)
- [`ma/mrecords.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/ma/mrecords.pyi)
- [`ma/testutils.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/ma/testutils.pyi)
- [`matlib.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/matlib.pyi)
- [`matrixlib/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/matrixlib/__init__.pyi)
- [`matrixlib/defmatrix.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/matrixlib/defmatrix.pyi)
- [`polynomial/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/__init__.pyi)
- [`polynomial/_polybase.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/_polybase.pyi)
- [`polynomial/chebyshev.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/chebyshev.pyi)
- [`polynomial/hermite.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/hermite.pyi)
- [`polynomial/hermite_e.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/hermite_e.pyi)
- [`polynomial/laguerre.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/laguerre.pyi)
- [`polynomial/legendre.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/legendre.pyi)
- [`polynomial/polynomial.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/polynomial.pyi)
- [`polynomial/polyutils.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/polynomial/polyutils.pyi)
- [`random/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/__init__.pyi)
- [`random/_generator.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/_generator.pyi)
- [`random/_mt19937.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/_mt19937.pyi)
- [`random/_pcg64.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/_pcg64.pyi)
- [`random/_philox.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/_philox.pyi)
- [`random/_pickle.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/_pickle.pyi)
- [`random/_sfc64.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/_sfc64.pyi)
- [`random/bit_generator.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/bit_generator.pyi)
- [`random/mtrand.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/random/mtrand.pyi)
- [`rec/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/rec/__init__.pyi)
- [`strings/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/strings/__init__.pyi)
- [`testing/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/testing/__init__.pyi)
- [`testing/_private/extbuild.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/testing/_private/extbuild.pyi)
- [`testing/_private/utils.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/testing/_private/utils.pyi)
- [`typing/__init__.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/typing/__init__.pyi)
- [`version.pyi`](https://github.com/numpy/numpy/blob/maintenance/2.4.x/numpy/version.pyi)