### PR TITLE
💚 fix failing docs deploy CI job after Zizmor fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
 
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 


### PR DESCRIPTION
#870 
as `persist-credentials: false` was blocking so setting up the remote url with the token  . should fix 

I also looked the approach you followed in `optype,` but i think for that we need to do more changes. 
please let me know if we should follow different way.
